### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a command line tool to convert the contents of a Confluence space into a MediaWiki imprt data format.
 
 ## Prerequisites
-1. PHP 7.x must be installed
+1. PHP >= 7.4 must be installed
 2. The `pandoc` tool must be installed and available in the `PATH` (https://pandoc.org/installing.html)
 
 ## Workflow


### PR DESCRIPTION
doc: PHP 7.4 minimum required

I had some files that resulted in filenames exceeding 255 characters.
WindowsFilename::__toString() throws an exception in this case.

This, however, is only valid in PHP 7.4 and higher and breaks the entire workflow.
I happened to have 7.3 from an older media wiki docker container (they've updated 'latest' just 30 mins ago).

https://bugs.php.net/bug.php?id=53648

Oh, and thanks a bunch for the toolchain! Awesome work!