### PR TITLE
Fix details macro

### DIFF
--- a/src/Composer/_defaultpages/Template/Details
+++ b/src/Composer/_defaultpages/Template/Details
@@ -1,5 +1,0 @@
-{{SimplePanel
-|type=info
-|title={{{headings|}}}
-|body={{{cql|}}}
-}}

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -233,6 +233,8 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface {
 				$this->dataLookup, $this->currentSpace, $this->currentPageTitle, $this->mainpage
 			),
 			new StructuredMacroRecentlyUpdated( $this->currentPageTitle ),
+			new StructuredMacroInclude( $this->dataLookup, $this->currentSpace ),
+			new StructuredMacroExcerptInclude( $this->dataLookup, $this->currentSpace ),
 			new Emoticon(),
 			new PreserveStructuredMacroTasksReport( $this->dataLookup ),
 			new Image(
@@ -255,8 +257,6 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface {
 				$currentPageTitle, $this->nsFileRepoCompat
 			),
 			new StructuredMacroContenByLabel( $this->currentPageTitle ),
-			new StructuredMacroInclude( $this->dataLookup, $this->currentSpace ),
-			new StructuredMacroExcerptInclude( $this->dataLookup, $this->currentSpace ),
 			new StructuredMacroAttachments(),
 			new ExpandMacro(),
 			new DetailsMacro(),

--- a/src/Converter/Processor/DetailsMacro.php
+++ b/src/Converter/Processor/DetailsMacro.php
@@ -2,17 +2,26 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
+use DOMDocument;
+use HalloWelt\MigrateConfluence\Converter\IProcessor;
+
 /**
  * <ac:structured-macro ac:name="details" ac:schema-version="1" ac:macro-id="...">
  *   <ac:parameter ac:name="id">control</ac:parameter>
  *     <ac:rich-text-body>
  *       <h3>Control details</h3>
  *       <table class="wrapped">
+ *     </ac:rich-text-body>
+ *     <ac:rich-text-body>
+ * 	     <h3>There may be multiple rich texts</h3>
+ *     </ac:rich-text-body>
+ *     ...
+ * </ac:structured-macro>
  */
-class DetailsMacro extends ConvertMacroToTemplateBase {
+class DetailsMacro implements IProcessor {
 
 	/**
-	 * @inheritDoc
+	 * @return string
 	 */
 	protected function getMacroName(): string {
 		return 'details';
@@ -21,7 +30,61 @@ class DetailsMacro extends ConvertMacroToTemplateBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function getWikiTextTemplateName(): string {
-		return 'Details';
+	public function process( DOMDocument $dom ): void {
+		$macros = $dom->getElementsByTagName( 'structured-macro' );
+		$requiredMacroName = $this->getMacroName();
+
+		// Collect all DOMElements in a non-live list
+		$actualMacros = [];
+		foreach ( $macros as $macro ) {
+			$macroName = $macro->getAttribute( 'ac:name' );
+			if ( $macroName !== $requiredMacroName ) {
+				continue;
+			}
+			$actualMacros[] = $macro;
+		}
+
+		foreach ( $actualMacros as $actualMacro ) {
+			$parentNode = $actualMacro->parentNode;
+
+			$detailsDiv = $dom->createElement( 'div' );
+			$detailsDiv->setAttribute( 'class', 'details' );
+
+			// Extract scalar parameters, store them as data attributes of 'div'
+			$parameterEls = $actualMacro->getElementsByTagName( 'parameter' );
+			foreach ( $parameterEls as $parameterEl ) {
+				$paramName = $parameterEl->getAttribute( 'ac:name' );
+				$paramValue = $parameterEl->nodeValue;
+
+				$detailsDiv->setAttribute( "data-$paramName", $paramValue );
+			}
+
+			// Extract rich text bodies
+			/** @var DOMNodeList $richTextBodies */
+			$richTextBodies = $actualMacro->getElementsByTagName( 'rich-text-body' );
+			$richTextBodyEls = [];
+			foreach ( $richTextBodies as $richTextBody ) {
+				$richTextBodyEls[] = $richTextBody;
+			}
+
+			if ( !empty( $richTextBodyEls ) ) {
+				foreach ( $richTextBodyEls as $richTextBodyEl ) {
+					// For some odd reason, iterating `$richTextBodyEl->childNodes` directly
+					// will give children of `$dom->firstChild`.
+					// Using `iterator_to_array` as an workaround here.
+					$childNodes = iterator_to_array( $richTextBodyEl->childNodes );
+					foreach ( $childNodes as $richTextBodyChildEl ) {
+						if ( $richTextBodyChildEl === $actualMacro ) {
+							continue;
+						}
+						$detailsDiv->appendChild( $richTextBodyChildEl );
+					}
+				}
+			}
+
+			$parentNode->insertBefore( $detailsDiv, $actualMacro );
+
+			$parentNode->removeChild( $actualMacro );
+		}
 	}
 }

--- a/tests/phpunit/Converter/Processor/DetailsMacroTest.php
+++ b/tests/phpunit/Converter/Processor/DetailsMacroTest.php
@@ -28,10 +28,13 @@ class DetailsMacroTest extends TestCase {
 		$processor = new DetailsMacro();
 		$processor->process( $dom );
 
-		$actualOutput = $dom->saveXML( $dom->documentElement );
-		$expectedOutput = file_get_contents( "$this->dir/details-macro-output.xml" );
+		$expectedDOM = new DOMDocument();
+		$expectedDOM->load( "$this->dir/details-macro-output.xml" );
 
-		$this->assertEquals( $expectedOutput, $actualOutput );
+		$this->assertEqualXMLStructure(
+			$expectedDOM->documentElement,
+			$dom->documentElement
+		);
 	}
 
 }

--- a/tests/phpunit/data/details-macro-input.xml
+++ b/tests/phpunit/data/details-macro-input.xml
@@ -1,8 +1,12 @@
 <xml xmlns:ac="sample_namespace">
     <ac:structured-macro ac:name="details">
-      <ac:parameter ac:name="id">Lorem</ac:parameter>
-      <ac:rich-text-body>
-        <h3>Ipsum dolor</h3>
-      </ac:rich-text-body>
+        <ac:parameter ac:name="id">Lorem</ac:parameter>
+        <ac:parameter ac:name="something">we have never seen before</ac:parameter>
+        <ac:rich-text-body>
+            <h3>Ipsum dolor</h3>
+        </ac:rich-text-body>
+        <ac:rich-text-body>
+            <h3>There may be multiple rich texts</h3>
+        </ac:rich-text-body>
     </ac:structured-macro>
 </xml>

--- a/tests/phpunit/data/details-macro-output.xml
+++ b/tests/phpunit/data/details-macro-output.xml
@@ -1,9 +1,6 @@
 <xml xmlns:ac="sample_namespace">
-    {{Details###BREAK###
- |id = Lorem###BREAK###
- |body = ###BREAK###
-
+    <div class="details" data-id="Lorem" data-something="we have never seen before">
         <h3>Ipsum dolor</h3>
-      }}###BREAK###
-
+        <h3>There may be multiple rich texts</h3>
+    </div>
 </xml>


### PR DESCRIPTION
* Refactor "DetailsMacro" to not use wiki template, but wrap contents in the "div". Arguments are stored as data attributes.
* Process transclusions before links, in that case order matters. Otherwise they're converted as links.