### PR TITLE
check for description content

### DIFF
--- a/src/Composer/Processor/Pages.php
+++ b/src/Composer/Processor/Pages.php
@@ -204,7 +204,8 @@ class Pages extends ProcessorBase {
 						// get description id
 						$descBodyId = $spaceDescriptionIdBodyIdMap[$descId];
 						$description = $this->workspace->getConvertedContent( $descBodyId );
-						if ( $description !== '' ) {
+						$strippedDescription = trim( preg_replace( '/<!--.*?-->/s', '', (string)$description ) );
+						if ( $strippedDescription !== '' ) {
 							$pageContent .= "[[Space description::$description]]\n";
 						}
 					}


### PR DESCRIPTION
If there is no content, its at least the comment 
 <!-- From bodyContent 223940236.mraw -->


if ( $description !== '' ) {
	$pageContent .= "[[Space description::$description]]\n";
}

still adds it.