### PR TITLE
Fix macros wrapped in heading

### DIFF
--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -38,6 +38,7 @@ use HalloWelt\MigrateConfluence\Converter\Processor\ExcerptMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\ExpandMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\GalleryMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\GliffyMacro;
+use HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading;
 use HalloWelt\MigrateConfluence\Converter\Processor\Image;
 use HalloWelt\MigrateConfluence\Converter\Processor\IncludeMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\InfoMacro;
@@ -301,6 +302,7 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface {
 			new Layout(),
 			new LayoutSection(),
 			new LayoutCell(),
+			new HoistMacroFromHeading(),
 			new AnchorMacro(),
 			new Placeholder(),
 			new InlineCommentMarker(),

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -20,6 +20,7 @@ use HalloWelt\MigrateConfluence\Converter\Postprocessor\NestedHeadings;
 use HalloWelt\MigrateConfluence\Converter\Postprocessor\RestorePStyleTag;
 use HalloWelt\MigrateConfluence\Converter\Postprocessor\RestoreTimeTag;
 use HalloWelt\MigrateConfluence\Converter\Postprocessor\TasksReportMacro as RestoreTasksReportMacro;
+use HalloWelt\MigrateConfluence\Converter\Preprocessor\dom\HoistMacroFromHeading;
 use HalloWelt\MigrateConfluence\Converter\Preprocessor\dom\SanitizeLinkContent;
 use HalloWelt\MigrateConfluence\Converter\Preprocessor\html\CDATAClosingFixer;
 use HalloWelt\MigrateConfluence\Converter\Processor\AlignMacro;
@@ -40,7 +41,6 @@ use HalloWelt\MigrateConfluence\Converter\Processor\ExcerptMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\ExpandMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\GalleryMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\GliffyMacro;
-use HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading;
 use HalloWelt\MigrateConfluence\Converter\Processor\Image;
 use HalloWelt\MigrateConfluence\Converter\Processor\IncludeMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\InfoMacro;
@@ -311,7 +311,6 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface {
 			new Layout(),
 			new LayoutSection(),
 			new LayoutCell(),
-			new HoistMacroFromHeading(),
 			new AnchorMacro(),
 			new Placeholder(),
 			new InlineCommentMarker(),
@@ -579,10 +578,11 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface {
 	 */
 	protected function preprocessDomSource( DOMDocument $dom ): void {
 		$preprocessors = [
-			new SanitizeLinkContent()
+			new SanitizeLinkContent(),
+			new HoistMacroFromHeading()
 		];
 
-		/** @var IHtmlPreprocessor $preprocessor */
+		/** @var IDomPreprocessor $preprocessor */
 		foreach ( $preprocessors as $preprocessor ) {
 			$preprocessor->preprocess( $dom );
 		}

--- a/src/Converter/IHtmlPreprocessor.php
+++ b/src/Converter/IHtmlPreprocessor.php
@@ -5,7 +5,6 @@ namespace HalloWelt\MigrateConfluence\Converter;
 interface IHtmlPreprocessor {
 
 	/**
-	 *
 	 * @param string $confluenceHTML
 	 * @return string
 	 */

--- a/src/Converter/Preprocessor/dom/HoistMacroFromHeading.php
+++ b/src/Converter/Preprocessor/dom/HoistMacroFromHeading.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace HalloWelt\MigrateConfluence\Converter\Processor;
+namespace HalloWelt\MigrateConfluence\Converter\Preprocessor\dom;
 
 use DOMDocument;
 use DOMElement;
-use HalloWelt\MigrateConfluence\Converter\IProcessor;
+use HalloWelt\MigrateConfluence\Converter\IDomPreprocessor;
 
 /**
  * Moves any <ac:structured-macro> or <ac:macro> that is a direct child of a heading element
@@ -17,7 +17,7 @@ use HalloWelt\MigrateConfluence\Converter\IProcessor;
  * If the heading contains only whitespace after the macro is removed, the
  * heading itself is also removed to avoid generating an empty heading.
  */
-class HoistMacroFromHeading implements IProcessor {
+class HoistMacroFromHeading implements IDomPreprocessor {
 
 	/** @var string[] */
 	private const HEADING_TAGS = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
@@ -28,7 +28,7 @@ class HoistMacroFromHeading implements IProcessor {
 	/**
 	 * @inheritDoc
 	 */
-	public function process( DOMDocument $dom ): void {
+	public function preprocess( DOMDocument $dom ): void {
 		foreach ( self::HEADING_TAGS as $tag ) {
 			$headings = $dom->getElementsByTagName( $tag );
 

--- a/src/Converter/Processor/HoistMacroFromHeading.php
+++ b/src/Converter/Processor/HoistMacroFromHeading.php
@@ -7,7 +7,7 @@ use DOMElement;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 /**
- * Moves any <ac:structured-macro> that is a direct child of a heading element
+ * Moves any <ac:structured-macro> or <ac:macro> that is a direct child of a heading element
  * (<h1>–<h6>) to immediately after that heading.
  *
  * Block-level macros inside headings cause pandoc to emit things like
@@ -21,6 +21,9 @@ class HoistMacroFromHeading implements IProcessor {
 
 	/** @var string[] */
 	private const HEADING_TAGS = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
+
+	/** @var string[] */
+	private const MACRO_TAGS = [ 'structured-macro', 'macro' ];
 
 	/**
 	 * @inheritDoc
@@ -46,10 +49,10 @@ class HoistMacroFromHeading implements IProcessor {
 	 * @return void
 	 */
 	private function hoistFromHeading( DOMElement $heading ): void {
-		// Collect only direct-child structured-macro elements
+		// Collect only direct-child structured-macro and macro elements
 		$macros = [];
 		foreach ( $heading->childNodes as $child ) {
-			if ( $child instanceof DOMElement && $child->localName === 'structured-macro' ) {
+			if ( $child instanceof DOMElement && in_array( $child->localName, self::MACRO_TAGS ) ) {
 				$macros[] = $child;
 			}
 		}
@@ -72,6 +75,13 @@ class HoistMacroFromHeading implements IProcessor {
 
 			// Keep subsequent macros ordered: next one goes after the one just inserted
 			$insertBefore = $macro->nextSibling;
+		}
+
+		// Trim whitespace from remaining text nodes
+		foreach ( $heading->childNodes as $child ) {
+			if ( $child->nodeType === XML_TEXT_NODE ) {
+				$child->nodeValue = trim( $child->nodeValue );
+			}
 		}
 
 		// Remove the heading if nothing meaningful remains

--- a/src/Converter/Processor/HoistMacroFromHeading.php
+++ b/src/Converter/Processor/HoistMacroFromHeading.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Converter\Processor;
+
+use DOMDocument;
+use DOMElement;
+use HalloWelt\MigrateConfluence\Converter\IProcessor;
+
+/**
+ * Moves any <ac:structured-macro> that is a direct child of a heading element
+ * (<h1>–<h6>) to immediately after that heading.
+ *
+ * Block-level macros inside headings cause pandoc to emit things like
+ *   = {{MacroStart|...}}{{MacroEnd}} =
+ * which MediaWiki cannot render correctly.
+ *
+ * If the heading contains only whitespace after the macro is removed, the
+ * heading itself is also removed to avoid generating an empty heading.
+ */
+class HoistMacroFromHeading implements IProcessor {
+
+	/** @var string[] */
+	private const HEADING_TAGS = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function process( DOMDocument $dom ): void {
+		foreach ( self::HEADING_TAGS as $tag ) {
+			$headings = $dom->getElementsByTagName( $tag );
+
+			// Snapshot to avoid mutating a live NodeList during iteration
+			$headingList = [];
+			foreach ( $headings as $heading ) {
+				$headingList[] = $heading;
+			}
+
+			foreach ( $headingList as $heading ) {
+				$this->hoistFromHeading( $heading );
+			}
+		}
+	}
+
+	/**
+	 * @param DOMElement $heading
+	 * @return void
+	 */
+	private function hoistFromHeading( DOMElement $heading ): void {
+		// Collect only direct-child structured-macro elements
+		$macros = [];
+		foreach ( $heading->childNodes as $child ) {
+			if ( $child instanceof DOMElement && $child->localName === 'structured-macro' ) {
+				$macros[] = $child;
+			}
+		}
+
+		if ( empty( $macros ) ) {
+			return;
+		}
+
+		$headingParent = $heading->parentNode;
+		$insertBefore = $heading->nextSibling;
+
+		foreach ( $macros as $macro ) {
+			$heading->removeChild( $macro );
+
+			if ( $insertBefore !== null ) {
+				$headingParent->insertBefore( $macro, $insertBefore );
+			} else {
+				$headingParent->appendChild( $macro );
+			}
+
+			// Keep subsequent macros ordered: next one goes after the one just inserted
+			$insertBefore = $macro->nextSibling;
+		}
+
+		// Remove the heading if nothing meaningful remains
+		if ( trim( $heading->textContent ) === '' ) {
+			$headingParent->removeChild( $heading );
+		}
+	}
+}

--- a/tests/phpunit/Converter/Preprocessor/SanitizeLinkContentTest.php
+++ b/tests/phpunit/Converter/Preprocessor/SanitizeLinkContentTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class SanitizeLinkContentTest extends TestCase {
 
 	/**
-	 * @covers HalloWelt\MigrateConfluence\Converter\Preprocessor\SanitizeLinkContent::preprocess
+	 * @covers HalloWelt\MigrateConfluence\Converter\Preprocessor\dom\SanitizeLinkContent::preprocess
 	 * @dataProvider provideExtractCases
 	 * @param string $input
 	 * @param string $expected

--- a/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
+++ b/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
@@ -3,13 +3,13 @@
 namespace HalloWelt\MigrateConfluence\Tests\Converter\Processor;
 
 use DOMDocument;
-use HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading;
+use HalloWelt\MigrateConfluence\Converter\Preprocessor\dom\HoistMacroFromHeading;
 use PHPUnit\Framework\TestCase;
 
 class HoistMacroFromHeadingTest extends TestCase {
 
 	/**
-	 * @covers HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading::process
+	 * @covers HalloWelt\MigrateConfluence\Converter\Preprocessor\dom\HoistMacroFromHeading::preprocess
 	 * @dataProvider provideHoistCases
 	 * @param string $input
 	 * @param string $expected
@@ -20,7 +20,7 @@ class HoistMacroFromHeadingTest extends TestCase {
 		$dom->loadXML( $input );
 
 		$processor = new HoistMacroFromHeading();
-		$processor->process( $dom );
+		$processor->preprocess( $dom );
 
 		$this->assertEquals( $expected, $dom->saveXML( $dom->documentElement ) );
 	}

--- a/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
+++ b/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
@@ -38,7 +38,11 @@ class HoistMacroFromHeadingTest extends TestCase {
 			],
 			'macro hoisted, heading with text kept' => [
 				"<root $ns><h2>Title <ac:structured-macro ac:name=\"panel\"/></h2></root>",
-				"<root $ns><h2>Title </h2><ac:structured-macro ac:name=\"panel\"/></root>",
+				"<root $ns><h2>Title</h2><ac:structured-macro ac:name=\"panel\"/></root>",
+			],
+			'macro hoisted, heading with text kept with plain text at the end' => [
+				"<root $ns><h2><ac:structured-macro ac:name=\"panel\"/> Title</h2></root>",
+				"<root $ns><h2>Title</h2><ac:structured-macro ac:name=\"panel\"/></root>",
 			],
 			'multiple macros in heading hoisted in order' => [
 				"<root $ns><h3><ac:structured-macro ac:name=\"a\"/><ac:structured-macro ac:name=\"b\"/>" .
@@ -56,6 +60,23 @@ class HoistMacroFromHeadingTest extends TestCase {
 			'macro placed before following sibling' => [
 				"<root $ns><h1><ac:structured-macro ac:name=\"x\"/></h1><p>next</p></root>",
 				"<root $ns><ac:structured-macro ac:name=\"x\"/><p>next</p></root>",
+			],
+			'ac:macro-only heading is removed' => [
+				"<root $ns><h1><ac:macro ac:name=\"detailssummary\"/></h1></root>",
+				"<root $ns><ac:macro ac:name=\"detailssummary\"/></root>",
+			],
+			'ac:macro hoisted, heading with text kept' => [
+				"<root $ns><h2>Title <ac:macro ac:name=\"panel\"/></h2></root>",
+				"<root $ns><h2>Title</h2><ac:macro ac:name=\"panel\"/></root>",
+			],
+			'ac:macro hoisted before following sibling' => [
+				"<root $ns><h1><ac:macro ac:name=\"x\"/></h1><p>next</p></root>",
+				"<root $ns><ac:macro ac:name=\"x\"/><p>next</p></root>",
+			],
+			'mixed ac:structured-macro and ac:macro both hoisted' => [
+				"<root $ns><h2><ac:structured-macro ac:name=\"a\"/><ac:macro ac:name=\"b\"/>" .
+				"</h2><p>after</p></root>",
+				"<root $ns><ac:structured-macro ac:name=\"a\"/><ac:macro ac:name=\"b\"/><p>after</p></root>",
 			],
 		];
 	}

--- a/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
+++ b/tests/phpunit/Converter/Processor/HoistMacroFromHeadingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Converter\Processor;
+
+use DOMDocument;
+use HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading;
+use PHPUnit\Framework\TestCase;
+
+class HoistMacroFromHeadingTest extends TestCase {
+
+	/**
+	 * @covers HalloWelt\MigrateConfluence\Converter\Processor\HoistMacroFromHeading::process
+	 * @dataProvider provideHoistCases
+	 * @param string $input
+	 * @param string $expected
+	 * @return void
+	 */
+	public function testProcess( string $input, string $expected ): void {
+		$dom = new DOMDocument();
+		$dom->loadXML( $input );
+
+		$processor = new HoistMacroFromHeading();
+		$processor->process( $dom );
+
+		$this->assertEquals( $expected, $dom->saveXML( $dom->documentElement ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public static function provideHoistCases(): array {
+		$ns = 'xmlns:ac="ac_ns" xmlns:ri="ri_ns"';
+
+		return [
+			'macro-only heading is removed' => [
+				"<root $ns><h1><ac:structured-macro ac:name=\"detailssummary\"/></h1></root>",
+				"<root $ns><ac:structured-macro ac:name=\"detailssummary\"/></root>",
+			],
+			'macro hoisted, heading with text kept' => [
+				"<root $ns><h2>Title <ac:structured-macro ac:name=\"panel\"/></h2></root>",
+				"<root $ns><h2>Title </h2><ac:structured-macro ac:name=\"panel\"/></root>",
+			],
+			'multiple macros in heading hoisted in order' => [
+				"<root $ns><h3><ac:structured-macro ac:name=\"a\"/><ac:structured-macro ac:name=\"b\"/>" .
+				"</h3><p>after</p></root>",
+				"<root $ns><ac:structured-macro ac:name=\"a\"/><ac:structured-macro ac:name=\"b\"/><p>after</p></root>",
+			],
+			'macro after last child appended to parent' => [
+				"<root $ns><h1><ac:structured-macro ac:name=\"details\"/></h1></root>",
+				"<root $ns><ac:structured-macro ac:name=\"details\"/></root>",
+			],
+			'no macro in heading unchanged' => [
+				"<root $ns><h1>Plain heading</h1></root>",
+				"<root $ns><h1>Plain heading</h1></root>",
+			],
+			'macro placed before following sibling' => [
+				"<root $ns><h1><ac:structured-macro ac:name=\"x\"/></h1><p>next</p></root>",
+				"<root $ns><ac:structured-macro ac:name=\"x\"/><p>next</p></root>",
+			],
+		];
+	}
+}


### PR DESCRIPTION
Adds a processor which moves any <ac:structured-macro> that is a direct child of a heading element to immediately after that heading to avoid stuff like `= {{MacroStart|...}}{{MacroEnd}} =`