### PR TITLE
Remove bailout from attachments, add bailout to comments

### DIFF
--- a/src/Analyzer/Processor/Attachments.php
+++ b/src/Analyzer/Processor/Attachments.php
@@ -75,11 +75,6 @@ class Attachments extends ProcessorBase {
 			$attachmentFilename = $properties['title'];
 		}
 
-		// Bail out if attachment object was already handled
-		if ( isset( $this->data['analyze-attachment-id-to-orig-filename-map'][$attachmentId] ) ) {
-			return;
-		}
-
 		if ( $attachmentFilename !== '' ) {
 			$this->data['analyze-attachment-id-to-orig-filename-map'][$attachmentId] = $attachmentFilename;
 		}

--- a/src/Analyzer/Processor/Comments.php
+++ b/src/Analyzer/Processor/Comments.php
@@ -18,6 +18,7 @@ class Comments extends ProcessorBase {
 		return [
 			'analyze-inline-comment-ids',
 			'analyze-body-content-id-to-comment-id-map',
+			'global-page-id-to-comment-ids-map'
 		];
 	}
 
@@ -82,6 +83,13 @@ class Comments extends ProcessorBase {
 		$pageId = isset( $properties['containerContent'] ) ? (int)$properties['containerContent'] : null;
 		if ( $pageId === null ) {
 			return;
+		}
+
+		// Bail out if comment was already handled
+		if ( isset( $this->data['global-page-id-to-comment-ids-map'][$pageId] ) ) {
+			if ( in_array( $commentId, $this->data['global-page-id-to-comment-ids-map'][$pageId] ) ) {
+				return;
+			}
 		}
 
 		// Find the body content ID for this comment


### PR DESCRIPTION
Removed bailout from attachments, because if only the first occurence of an attachment definition object is processed and the actual file is part of another source file with also that definition, the file is missing in the end.

Added bailout to comments, so that duplicates of comments are not inserted in the page