### PR TITLE
Add version info

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: prepare-release
+#
+# Currently this workflow is rather useless. It creates an updated VERSION file that is
+# then discarded. The aim is later to produce releases semi-automatically with it.
+#
+
+on:
+  workflow_run:
+    workflows: ["basic-tests"]
+    types:
+      - completed
+  push:
+    tags:
+      - '*'
+
+jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set version from tag
+        id: set_version
+        run: |
+          ./bin/mkversion.sh --from-env
+
+      # TODO we could let git-archive do this job and define exclusions in .gitattributes.
+      - name: create zip file for release
+        run: zip -r "migrate-confluence-{{ github.ref_name }}" bin doc docker src tests .phpcs.xml box.json composer.json Dockerfile LICENSE README.md VERSION
+        if: startsWith(github.ref, 'refs/tags/')
+
+      # TODO do we want to auto-create releases for each tag? If yes, how do we handle release notes?
+      # - name: create release
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     files: "migrate-confluence-{{ github.ref_name }}".zip
+      #   if: startsWith(github.ref, 'refs/tags/')

--- a/.phpunit.xml
+++ b/.phpunit.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<phpunit bootstrap="vendor/autoload.php">
-	<testsuites>
-		<testsuite name="all">
-			<directory suffix="Test.php">./tests/phpunit</directory>
-		</testsuite>
-	</testsuites>
-</phpunit>

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+dev-unversioned

--- a/bin/migrate-confluence
+++ b/bin/migrate-confluence
@@ -5,6 +5,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 use HalloWelt\MediaWiki\Lib\Migration\CliApp;
 use HalloWelt\MigrateConfluence\Command\CheckResult;
+use HalloWelt\MigrateConfluence\Command\GetVersion;
 
 $config = [
 	'file-extension-whitelist' => [ 'xml' ],
@@ -38,4 +39,5 @@ $config = [
 
 $application = new CliApp( $config );
 $application->add( new CheckResult() );
+$application->add( new GetVersion() );
 $application->run();

--- a/bin/mkversion.sh
+++ b/bin/mkversion.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+COMMIT_HASH="$(git rev-parse HEAD)"
+
+case "${1:-}" in
+    "--clean")
+        printf 'dev-unversioned' > ../VERSION
+        ;;
+    "--from-env")
+        printf "${GITHUB_REF_NAME:-dev-no-env-$COMMIT_HASH}" > ../VERSION
+        ;;
+    "")
+        printf 'dev-%s' "$COMMIT_HASH" > ../VERSION
+        ;;
+    *)
+        echo "Usage: $(basename "$0") [--clean|--from-env]" >&2
+        exit 1
+        ;;
+esac

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"scripts": {
 		"unittest": [
-			"vendor/phpunit/phpunit/phpunit --configuration .phpunit.xml"
+			"vendor/phpunit/phpunit/phpunit --configuration phpunit.xml"
 		],
 		"test": [
 			"parallel-lint . --exclude vendor --exclude node_modules",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpunit bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite name="Converter">
+        <testsuite name="all">
             <directory suffix="Test.php">./tests/phpunit</directory>
         </testsuite>
     </testsuites>

--- a/src/Analyzer/ConfluenceAnalyzer.php
+++ b/src/Analyzer/ConfluenceAnalyzer.php
@@ -28,6 +28,7 @@ use HalloWelt\MigrateConfluence\Utility\FilenameBuilder;
 use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
 use HalloWelt\MigrateConfluence\Utility\TitleBuilder;
 use HalloWelt\MigrateConfluence\Utility\TitleValidityChecker;
+use HalloWelt\MigrateConfluence\Utility\Version;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -94,6 +95,12 @@ class ConfluenceAnalyzer extends AnalyzerBase
 	 */
 	private function initDBLog(): void {
 		$this->dbLog = new DBLog( $this->workspaceDB );
+		$this->dbLog->addLogEntry(
+			'info',
+			'analyze',
+			__CLASS__,
+			sprintf( 'use version %s', Version::getVersion() )
+		);
 	}
 
 	/**

--- a/src/Analyzer/ConfluenceAnalyzer.php
+++ b/src/Analyzer/ConfluenceAnalyzer.php
@@ -99,7 +99,7 @@ class ConfluenceAnalyzer extends AnalyzerBase
 			'info',
 			'analyze',
 			__CLASS__,
-			sprintf( 'use version %s', Version::getVersion() )
+			sprintf( '[%s] use version %s', date( 'c' ), Version::getVersion() )
 		);
 	}
 

--- a/src/Command/Convert.php
+++ b/src/Command/Convert.php
@@ -95,7 +95,7 @@ class Convert extends CommandConvert {
 				'info',
 				'convert',
 				__CLASS__,
-				sprintf( 'use version %s', Version::getVersion() )
+				sprintf( '[%s] use version %s', date( 'c' ), Version::getVersion() )
 			);
 		}
 

--- a/src/Command/Convert.php
+++ b/src/Command/Convert.php
@@ -10,6 +10,7 @@ use HalloWelt\MigrateConfluence\Database\WorkspaceDB;
 use HalloWelt\MigrateConfluence\IDestinationPathAware;
 use HalloWelt\MigrateConfluence\Utility\DBLog;
 use HalloWelt\MigrateConfluence\Utility\PipeToDB;
+use HalloWelt\MigrateConfluence\Utility\Version;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -88,6 +89,15 @@ class Convert extends CommandConvert {
 
 		$workers = (int)$input->getOption( 'workers' );
 		$isWorker = $input->hasParameterOption( '--worker' );
+
+		if ( !$isWorker ) {
+			$this->dbLog->addLogEntry(
+				'info',
+				'convert',
+				__CLASS__,
+				sprintf( 'use version %s', Version::getVersion() )
+			);
+		}
 
 		if ( $workers > 1 && !$isWorker ) {
 			return $this->spawnWorkers( $input, $output, $workers );

--- a/src/Command/GetVersion.php
+++ b/src/Command/GetVersion.php
@@ -2,10 +2,10 @@
 
 namespace HalloWelt\MigrateConfluence\Command;
 
+use HalloWelt\MigrateConfluence\Utility\Version;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use HalloWelt\MigrateConfluence\Utility\Version;
 
 class GetVersion extends Command {
 

--- a/src/Command/GetVersion.php
+++ b/src/Command/GetVersion.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use HalloWelt\MigrateConfluence\Utility\Version;
+
+class GetVersion extends Command {
+
+	/**
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this
+			->setName( 'version' )
+			->setDescription( 'Print version information' );
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$version = Version::getVersion();
+		if ( !$version ) {
+			$output->getErrorOutput()->writeln( 'Version information not found in composer.json' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( sprintf( $output->isVerbose() ? "tool: %s\nphp:  %s" : '%s', $version, PHP_VERSION ) );
+
+		return Command::SUCCESS;
+	}
+
+}

--- a/src/Composer/ConfluenceComposer.php
+++ b/src/Composer/ConfluenceComposer.php
@@ -17,6 +17,7 @@ use HalloWelt\MigrateConfluence\Utility\ComposerDeploymentInfo;
 use HalloWelt\MigrateConfluence\Utility\DBComposerDataLookup;
 use HalloWelt\MigrateConfluence\Utility\DBLog;
 use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
+use HalloWelt\MigrateConfluence\Utility\Version;
 use Symfony\Component\Console\Output\Output;
 
 class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, IDestinationPathAware {
@@ -68,6 +69,12 @@ class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, 
 	public function buildXML( Builder $builder ): void {
 		$workspaceDB = new WorkspaceDB( $this->dest . '/workspace.sqlite' );
 		$dbLog = new DBLog( $workspaceDB );
+		$dbLog->addLogEntry(
+			'info',
+			'compose',
+			__CLASS__,
+			sprintf( 'use version %s', Version::getVersion() )
+		);
 		$composerDataLookup = new DBComposerDataLookup( $workspaceDB );
 		$deploymentInfo = new ComposerDeploymentInfo();
 		$processors = [

--- a/src/Composer/ConfluenceComposer.php
+++ b/src/Composer/ConfluenceComposer.php
@@ -73,7 +73,7 @@ class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, 
 			'info',
 			'compose',
 			__CLASS__,
-			sprintf( 'use version %s', Version::getVersion() )
+			sprintf( '[%s] use version %s', date( 'c' ), Version::getVersion() )
 		);
 		$composerDataLookup = new DBComposerDataLookup( $workspaceDB );
 		$deploymentInfo = new ComposerDeploymentInfo();

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -88,6 +88,7 @@ use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
 use HalloWelt\MigrateConfluence\Utility\PipeToDB;
 use HalloWelt\MigrateConfluence\Utility\TocMacroUsage;
+use HalloWelt\MigrateConfluence\Utility\Version;
 use SplFileInfo;
 use Symfony\Component\Console\Output\Output;
 

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -88,7 +88,6 @@ use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
 use HalloWelt\MigrateConfluence\Utility\PipeToDB;
 use HalloWelt\MigrateConfluence\Utility\TocMacroUsage;
-use HalloWelt\MigrateConfluence\Utility\Version;
 use SplFileInfo;
 use Symfony\Component\Console\Output\Output;
 

--- a/src/Extractor/ConfluenceExtractor.php
+++ b/src/Extractor/ConfluenceExtractor.php
@@ -9,6 +9,7 @@ use HalloWelt\MigrateConfluence\Database\WorkspaceDB;
 use HalloWelt\MigrateConfluence\IDestinationPathAware;
 use HalloWelt\MigrateConfluence\Utility\DBLog;
 use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
+use HalloWelt\MigrateConfluence\Utility\Version;
 use SplFileInfo;
 
 class ConfluenceExtractor extends ExtractorBase implements IDestinationPathAware {
@@ -53,6 +54,12 @@ class ConfluenceExtractor extends ExtractorBase implements IDestinationPathAware
 	 */
 	private function initDBLog(): void {
 		$this->dbLog = new DBLog( $this->workspaceDB );
+		$this->dbLog->addLogEntry(
+			'info',
+			'extract',
+			__CLASS__,
+			sprintf( 'use version %s', Version::getVersion() )
+		);
 	}
 
 	/**

--- a/src/Extractor/ConfluenceExtractor.php
+++ b/src/Extractor/ConfluenceExtractor.php
@@ -58,7 +58,7 @@ class ConfluenceExtractor extends ExtractorBase implements IDestinationPathAware
 			'info',
 			'extract',
 			__CLASS__,
-			sprintf( 'use version %s', Version::getVersion() )
+			sprintf( '[%s] use version %s', date( 'c' ), Version::getVersion() )
 		);
 	}
 

--- a/src/Utility/Version.php
+++ b/src/Utility/Version.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Utility;
+
+class Version {
+
+    private static $version = null;
+
+    public static function getVersion(): string {
+        if ( static::$version === null ) {
+            $rawVersion = file_get_contents( __DIR__ . '/../../VERSION' );
+            if ( is_string( $rawVersion ) ) {
+                $rawVersion = trim( $rawVersion );
+            }
+            if ( $rawVersion ) {
+                static::$version = $rawVersion;
+            }
+        }
+        return static::$version ?? 'unknown';
+    }
+
+}

--- a/src/Utility/Version.php
+++ b/src/Utility/Version.php
@@ -2,21 +2,27 @@
 
 namespace HalloWelt\MigrateConfluence\Utility;
 
+/**
+ * provide the tool's version
+ */
 class Version {
 
-    private static $version = null;
+	/**
+	 * @var string|null deduced version
+	 */
+	private static $version = null;
 
-    public static function getVersion(): string {
-        if ( static::$version === null ) {
-            $rawVersion = file_get_contents( __DIR__ . '/../../VERSION' );
-            if ( is_string( $rawVersion ) ) {
-                $rawVersion = trim( $rawVersion );
-            }
-            if ( $rawVersion ) {
-                static::$version = $rawVersion;
-            }
-        }
-        return static::$version ?? 'unknown';
-    }
+	public static function getVersion(): string {
+		if ( static::$version === null ) {
+			$rawVersion = file_get_contents( __DIR__ . '/../../VERSION' );
+			if ( is_string( $rawVersion ) ) {
+				$rawVersion = trim( $rawVersion );
+			}
+			if ( $rawVersion ) {
+				static::$version = $rawVersion;
+			}
+		}
+		return static::$version ?? 'unknown';
+	}
 
 }

--- a/tests/phpunit/Utility/Version/VersionTest.php
+++ b/tests/phpunit/Utility/Version/VersionTest.php
@@ -7,22 +7,34 @@ use PHPUnit\Framework\TestCase;
 
 class VersionTest extends TestCase {
 
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Utility\Version::getVersion
+	 */
 	public function testGetVersionReturnsNonemptyString(): void {
 		$version = Version::getVersion();
 		$this->assertIsString( $version );
 		$this->assertNotEmpty( $version );
 	}
 
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Utility\Version::getVersion
+	 */
 	public function testGetVersionMatchesVersionFile(): void {
 		$expectedVersion = trim( file_get_contents( __DIR__ . '/../../../../VERSION' ) );
 		$this->assertSame( $expectedVersion, Version::getVersion() );
 	}
 
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Utility\Version::getVersion
+	 */
 	public function testGetVersionIsTrimmed(): void {
 		$version = Version::getVersion();
 		$this->assertSame( trim( $version ), $version );
 	}
 
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Utility\Version::getVersion
+	 */
 	public function testGetVersionIsStable(): void {
 		$first = Version::getVersion();
 		$second = Version::getVersion();

--- a/tests/phpunit/Utility/Version/VersionTest.php
+++ b/tests/phpunit/Utility/Version/VersionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Utility;
+
+use HalloWelt\MigrateConfluence\Utility\Version;
+use PHPUnit\Framework\TestCase;
+
+class VersionTest extends TestCase {
+
+	public function testGetVersionReturnsNonemptyString(): void {
+		$version = Version::getVersion();
+		$this->assertIsString( $version );
+		$this->assertNotEmpty( $version );
+	}
+
+	public function testGetVersionMatchesVersionFile(): void {
+		$expectedVersion = trim( file_get_contents( __DIR__ . '/../../../../VERSION' ) );
+		$this->assertSame( $expectedVersion, Version::getVersion() );
+	}
+
+	public function testGetVersionIsTrimmed(): void {
+		$version = Version::getVersion();
+		$this->assertSame( trim( $version ), $version );
+	}
+
+	public function testGetVersionIsStable(): void {
+		$first = Version::getVersion();
+		$second = Version::getVersion();
+		$this->assertSame( $first, $second );
+	}
+}


### PR DESCRIPTION
This changeset adds version information to two places:

- a new command `version` prints the current version of the tool
- during runs the steps write their used version into the workspace DB as log messages with level `info`

The clean-up of phpunit files is unrelated, but seemed not to merit its own pull request.