### PR TITLE
fix unittest warnings

### DIFF
--- a/tests/phpunit/Database/WorkspaceDbMock.php
+++ b/tests/phpunit/Database/WorkspaceDbMock.php
@@ -414,7 +414,6 @@ class WorkspaceDbMock {
 			$wikiTitle,
 			'20240101000000',
 			'',
-			'current',
 			'1',
 			-1,
 			[ $bodyContentId ],


### PR DESCRIPTION
There was a DB mock call with a removed parameter. The tests in the original PR strangely didn't catch it.