### PR TITLE
fix type warnings

### DIFF
--- a/src/Analyzer/Processor/Attachments.php
+++ b/src/Analyzer/Processor/Attachments.php
@@ -48,7 +48,7 @@ class Attachments extends ProcessorBase {
 		if ( $attachmentId === null ) {
 			return;
 		}
-		$referenceAttachmentId = (int)$attachmentId;
+		$referenceAttachmentId = $attachmentId;
 
 		$confluenceFilename = '';
 		if ( isset( $properties['fileName'] ) ) {
@@ -68,9 +68,8 @@ class Attachments extends ProcessorBase {
 			$containerContentId = (int)$properties['containerContent'];
 		}
 
-		$contentStatus = '';
 		if ( isset( $properties['contentStatus'] ) ) {
-			$contentStatus = $properties['contentStatus'];
+			$properties['contentStatus'];
 		}
 
 		$contentStatus = '';
@@ -174,7 +173,6 @@ class Attachments extends ProcessorBase {
 	 * @return string
 	 */
 	private function guessFileExtension( string $attachmentReference, string $confluenceFilename ): string {
-		$fileExtension = '';
 		$file = new SplFileInfo( $attachmentReference );
 		$fileExtension = $file->getExtension();
 

--- a/src/Analyzer/Processor/Comments.php
+++ b/src/Analyzer/Processor/Comments.php
@@ -48,7 +48,7 @@ class Comments extends ProcessorBase {
 			$this->xmlReader->next();
 		}
 
-		$contentStatus = $properties['contentStatus'] ?? null;
+		$properties['contentStatus'] ?? null;
 
 		if ( $commentId === -1 ) {
 			return;
@@ -61,8 +61,8 @@ class Comments extends ProcessorBase {
 		}
 
 		$bodyContentIds = [];
-		if ( isset( $collection['bodyContents'] ) ) {
-			$bodyContentIds = $collection['bodyContents'];
+		if ( isset( $properties['bodyContents'] ) ) {
+			$bodyContentIds = $properties['bodyContents'];
 		}
 		// A fallback mechanism for body content IDs in case they are not found in the collection
 		// is placed in the ConfluenceAnalyzer, which will attempt to retrieve them from the

--- a/src/Analyzer/Processor/SpaceDescription.php
+++ b/src/Analyzer/Processor/SpaceDescription.php
@@ -96,9 +96,8 @@ class SpaceDescription extends ProcessorBase {
 			$originalVersionId = (int)$properties['originalVersion'];
 		}
 
-		$contentStatus = null;
 		if ( isset( $properties['contentStatus'] ) ) {
-			$contentStatus = $properties['contentStatus'];
+			$properties['contentStatus'];
 		}
 
 		if ( !$this->migrationConfig->getIncludeHistory() && $originalVersionId > 0 ) {

--- a/src/Analyzer/Processor/Spaces.php
+++ b/src/Analyzer/Processor/Spaces.php
@@ -100,7 +100,7 @@ class Spaces extends ProcessorBase {
 	 * @return string
 	 */
 	private function sanitizeUserSpaceKey( $spaceKey, $spaceName ) {
-		$spaceKey = substr( $spaceKey, 1, strlen( $spaceKey ) - 1 );
+		$spaceKey = substr( (string)$spaceKey, 1, strlen( (string)$spaceKey ) - 1 );
 		if ( is_numeric( $spaceKey ) ) {
 			$spaceKey = $spaceName;
 		}

--- a/src/Command/Analyze.php
+++ b/src/Command/Analyze.php
@@ -63,7 +63,7 @@ class Analyze extends CommandAnalyze {
 			if ( $analyzer instanceof IDestinationPathAware ) {
 				$analyzer->setDestinationPath( $this->dest );
 			}
-			$result = $analyzer->analyze( $this->currentFile );
+			$analyzer->analyze( $this->currentFile );
 			// TODO: Evaluate result
 		}
 		return true;
@@ -84,7 +84,7 @@ class Analyze extends CommandAnalyze {
 					$config = array_merge( $config, $yaml );
 				} catch ( ParseException $e ) {
 					$this->output->writeln( 'Invalid config file provided' );
-					exit( true );
+					exit( 1 );
 				}
 			}
 		}

--- a/src/Command/CheckResult.php
+++ b/src/Command/CheckResult.php
@@ -63,8 +63,9 @@ class CheckResult extends Command {
 		foreach ( $textEls as $textEl ) {
 			$wikiText = $textEl->nodeValue;
 
-			preg_replace_callback( '#\[\[(.*?)\]\]#', function ( $matches ) {
+			preg_replace_callback( '#\[\[(.*?)\]\]#', function ( $matches ): string {
 				$this->checkLink( $matches[1] );
+				return $matches[0];
 			}, $wikiText );
 		}
 

--- a/src/Command/Compose.php
+++ b/src/Command/Compose.php
@@ -82,7 +82,7 @@ class Compose extends CommandCompose {
 					$config = array_merge( $config, $yaml );
 				} catch ( ParseException $e ) {
 					$this->output->writeln( 'Invalid config file provided' );
-					exit( true );
+					exit( 1 );
 				}
 			}
 		}

--- a/src/Command/Convert.php
+++ b/src/Command/Convert.php
@@ -109,7 +109,9 @@ class Convert extends CommandConvert {
 				$this->storeWorkerResponse( $line );
 				$line = fgets( $this->pipe );
 			}
-			fclose( $this->pipe );
+			$pipe = $this->pipe;
+			$this->pipe = false;
+			fclose( $pipe );
 		}
 
 		return $returnValue;
@@ -326,6 +328,8 @@ class Convert extends CommandConvert {
 
 	/**
 	 * Filter the file list to only the slice belonging to this worker.
+	 *
+	 * @return void
 	 */
 	protected function makeFileList() {
 		parent::makeFileList();
@@ -363,13 +367,13 @@ class Convert extends CommandConvert {
 					$config = array_merge( $config, $yaml );
 				} catch ( ParseException $e ) {
 					$this->output->writeln( 'Invalid config file provided' );
-					exit( true );
+					exit( 1 );
 				}
 			}
 		}
 	}
 
-	private function makeTargetPathname() {
+	private function makeTargetPathname(): void {
 		$this->targetPathname = str_replace(
 			$this->src,
 			$this->wikiTextBasePath,
@@ -378,7 +382,7 @@ class Convert extends CommandConvert {
 		$this->targetPathname = preg_replace( '#\.mraw$#', '.wiki', $this->targetPathname );
 	}
 
-	private function ensureTargetPath() {
+	private function ensureTargetPath(): void {
 		$baseTargetPath = dirname( $this->targetPathname );
 		if ( !file_exists( $baseTargetPath ) ) {
 			mkdir( $baseTargetPath, 0755, true );

--- a/src/Command/Extract.php
+++ b/src/Command/Extract.php
@@ -99,7 +99,7 @@ class Extract extends CommandExtract {
 					$config = array_merge( $config, $yaml );
 				} catch ( ParseException $e ) {
 					$this->output->writeln( 'Invalid config file provided' );
-					exit( true );
+					exit( 1 );
 				}
 			}
 		}

--- a/src/Command/GetVersion.php
+++ b/src/Command/GetVersion.php
@@ -5,6 +5,7 @@ namespace HalloWelt\MigrateConfluence\Command;
 use HalloWelt\MigrateConfluence\Utility\Version;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GetVersion extends Command {
@@ -26,7 +27,9 @@ class GetVersion extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$version = Version::getVersion();
 		if ( !$version ) {
-			$output->getErrorOutput()->writeln( 'Version information not found in composer.json' );
+			if ( $output instanceof ConsoleOutputInterface ) {
+				$output->getErrorOutput()->writeln( 'Version information not found in composer.json' );
+			}
 			return Command::FAILURE;
 		}
 

--- a/src/Composer/Processor/Comments.php
+++ b/src/Composer/Processor/Comments.php
@@ -55,7 +55,7 @@ class Comments extends ProcessorBase {
 				continue;
 			}
 
-			if ( $wikiTitle === null || $wikiTitle === '' ) {
+			if ( $wikiTitle === '' ) {
 				continue;
 			}
 

--- a/src/Composer/Processor/Pages.php
+++ b/src/Composer/Processor/Pages.php
@@ -139,7 +139,7 @@ class Pages extends ProcessorBase {
 	 * @return string
 	 */
 	private function wrapSpaceDescription( string $description ): string {
-		$strippedDescription = trim( preg_replace( '/<!-- From bodyContent .*?-->/s', '', (string)$description ) );
+		$strippedDescription = trim( preg_replace( '/<!-- From bodyContent .*?-->/s', '', $description ) );
 		if ( $strippedDescription === '' ) {
 			return '';
 		}

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -246,7 +246,7 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface, I
 				$this->confluencePageTitle = $this->workspaceDB->getConfluencePageTitleFromPageId( $this->pageId )
 					?? '';
 				$this->wikiPageTitle = $this->workspaceDB->getWikiPageTitleFromPageId( $this->pageId )
-					?? 'not_current_revision_' . $this->pageId;
+					?? 'not_current_revision_' . (string)$this->pageId;
 			} elseif ( $this->workspaceDB->pageIdExists( $contentId ) ) {
 				$this->contentType = 'page';
 				$this->currentSpace = $this->getSpaceIdFromPageId( $contentId );
@@ -255,7 +255,7 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface, I
 				$this->confluencePageTitle = $this->workspaceDB->getConfluencePageTitleFromPageId( $this->pageId )
 					?? '';
 				$this->wikiPageTitle = $this->workspaceDB->getWikiPageTitleFromPageId( $this->pageId )
-					?? 'not_current_revision_' . $this->pageId;
+					?? 'not_current_revision_' . (string)$this->pageId;
 			} elseif ( $this->workspaceDB->blogPostIdExists( $contentId ) ) {
 				$this->contentType = 'blogPost';
 				$this->currentSpace = $this->getSpaceIdFromBlogPostId( $contentId );
@@ -265,7 +265,7 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface, I
 					$this->pageId
 				) ?? '';
 				$this->wikiPageTitle = $this->workspaceDB->getWikiBlogPostTitleFromBlogPostId( $this->pageId )
-					?? 'not_current_revision_' . $this->pageId;
+					?? 'not_current_revision_' . (string)$this->pageId;
 			} elseif ( $this->workspaceDB->commentIdExists( $contentId ) ) {
 				$this->contentType = 'comment';
 				$this->pageId = $contentId;
@@ -839,7 +839,7 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface, I
 		}
 		if ( $exceed !== '' ) {
 			$method = 'addInvalidBodyContent';
-			if ( strpos( $this->rawFile->getFileInfo(), 0, 3 ) === 'pt_' ) {
+			if ( substr( $this->rawFile->getFilename(), 0, 3 ) === 'pt_' ) {
 				$method = 'addInvalidPageTemplateContent';
 			}
 			if ( $exceed >= 512 ) {

--- a/src/Converter/IHtmlPreprocessor.php
+++ b/src/Converter/IHtmlPreprocessor.php
@@ -8,5 +8,5 @@ interface IHtmlPreprocessor {
 	 * @param string $confluenceHTML
 	 * @return string
 	 */
-	public function preprocess( string $confluenceHTML ): string;
+	public function preprocess( string $confluenceHTML ): ?string;
 }

--- a/src/Converter/IPostprocessor.php
+++ b/src/Converter/IPostprocessor.php
@@ -9,5 +9,5 @@ interface IPostprocessor {
 	 * @param string $wikiText
 	 * @return string
 	 */
-	public function postprocess( string $wikiText ): string;
+	public function postprocess( string $wikiText ): ?string;
 }

--- a/src/Converter/Postprocessor/CodeMacro.php
+++ b/src/Converter/Postprocessor/CodeMacro.php
@@ -8,8 +8,10 @@ class CodeMacro implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$wikiText = preg_replace_callback(
 			'#<div class="PRESERVESYNTAXHIGHLIGHT"(.*?)>(.*?)</div>#si', function ( $matches ) {
 				$attribs = $this->getAttributes( $matches[1] );

--- a/src/Converter/Postprocessor/FixImagesWithExternalUrl.php
+++ b/src/Converter/Postprocessor/FixImagesWithExternalUrl.php
@@ -8,8 +8,10 @@ class FixImagesWithExternalUrl implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$wikiText = preg_replace_callback(
 			"/\[\[File:(http[s]?:\/\/.*)]]/",
 			static function ( $matches ) {

--- a/src/Converter/Postprocessor/FixLineBreakInHeadings.php
+++ b/src/Converter/Postprocessor/FixLineBreakInHeadings.php
@@ -8,9 +8,11 @@ class FixLineBreakInHeadings implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
-		$callback = static function ( $matches ) {
+	public function postprocess( string $wikiText ): string|null {
+		$callback = static function ( $matches ): string {
 			$openTag = $matches[1];
 			$content = $matches[2];
 			$closeTag = $matches[3];

--- a/src/Converter/Postprocessor/FixMultilineTable.php
+++ b/src/Converter/Postprocessor/FixMultilineTable.php
@@ -21,7 +21,7 @@ class FixMultilineTable implements IPostprocessor {
 			$processedWikiText = preg_replace_callback(
 				self::TABLE_REGEX,
 				function ( array $match ): string {
-					return $this->normalizeTable( $match[0] );
+					return $this->normalizeTable( $match[0] ) ?? $match[0];
 				},
 				$previousWikiText
 			);
@@ -34,7 +34,7 @@ class FixMultilineTable implements IPostprocessor {
 		return $processedWikiText;
 	}
 
-	private function normalizeTable( string $tableText ): string {
+	private function normalizeTable( string $tableText ): string|null {
 		$blockCharsRegex = '[' . preg_quote( implode( '', self::BLOCK_CHARS ), '/' ) . ']';
 
 		// Remove blank lines between table rows and cells

--- a/src/Converter/Postprocessor/FixMultilineTemplate.php
+++ b/src/Converter/Postprocessor/FixMultilineTemplate.php
@@ -8,8 +8,10 @@ class FixMultilineTemplate implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$wikiText = preg_replace_callback(
 			'/\{\{(.*?)\}\}/s',
 			static function ( $match ) {

--- a/src/Converter/Postprocessor/NestedHeadings.php
+++ b/src/Converter/Postprocessor/NestedHeadings.php
@@ -49,7 +49,7 @@ class NestedHeadings implements IPostprocessor {
 		preg_match( $this->regEx, $line, $matches );
 
 		if ( count( $matches ) > 0 ) {
-			$orig = $matches[0];
+			$matches[0];
 			$headingLevel = $matches[2];
 			$text = $matches[3];
 
@@ -69,7 +69,7 @@ class NestedHeadings implements IPostprocessor {
 		$line = $lines[$index];
 		preg_match( $this->regEx, $line, $matches );
 		while ( count( $matches ) > 0 ) {
-			$orig = $matches[0];
+			$matches[0];
 			$listLevel = $matches[1];
 			$text = $matches[3];
 

--- a/src/Converter/Postprocessor/RestoreExcerptMacro.php
+++ b/src/Converter/Postprocessor/RestoreExcerptMacro.php
@@ -8,8 +8,10 @@ class RestoreExcerptMacro implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		return preg_replace_callback(
 			'/#####EXCERPTBLOCKOPEN\|(.*?)\|(.*?)#####(.*?)#####EXCERPTBLOCKCLOSE#####/si',
 			static function ( $matches ) {

--- a/src/Converter/Postprocessor/RestorePStyleTag.php
+++ b/src/Converter/Postprocessor/RestorePStyleTag.php
@@ -8,8 +8,10 @@ class RestorePStyleTag implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$newWikiText = preg_replace_callback(
 			'/\\\\?#####PRESERVEPSTYLEOPEN (.*?)#####(.*?)#####PRESERVEPSTYLECLOSE#####/si',
 			static function ( $matches ) {

--- a/src/Converter/Postprocessor/RestoreTimeTag.php
+++ b/src/Converter/Postprocessor/RestoreTimeTag.php
@@ -8,8 +8,10 @@ class RestoreTimeTag implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$newWikiText = preg_replace(
 			'#<span class="PRESERVEDATETIME">(.*?)</span>#si',
 			'<datetime>$1</datetime>',

--- a/src/Converter/Postprocessor/TasksReportMacro.php
+++ b/src/Converter/Postprocessor/TasksReportMacro.php
@@ -8,8 +8,10 @@ class TasksReportMacro implements IPostprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function postprocess( string $wikiText ): string {
+	public function postprocess( string $wikiText ): string|null {
 		$newWikiText = preg_replace(
 			'#<div class="PRESERVETASKSREPORT"(.*?)>.*?</div>#si',
 			'<taskreport$1/>',

--- a/src/Converter/Preprocessor/html/CDATAClosingFixer.php
+++ b/src/Converter/Preprocessor/html/CDATAClosingFixer.php
@@ -14,8 +14,10 @@ class CDATAClosingFixer implements IHtmlPreprocessor {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @return null|string
 	 */
-	public function preprocess( string $confluenceHTML ): string {
+	public function preprocess( string $confluenceHTML ): string|null {
 		$confluenceHTML = preg_replace_callback(
 			$this->pattern,
 			function ( $matches ) {

--- a/src/Converter/Processor/AlignMacro.php
+++ b/src/Converter/Processor/AlignMacro.php
@@ -5,7 +5,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 use DOMDocument;
 use DOMElement;
 use DOMException;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 class AlignMacro implements IProcessor {
@@ -37,12 +36,12 @@ class AlignMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
 	 * @throws DOMException
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroName = $node->getAttribute( 'ac:name' );
 
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
@@ -64,13 +63,13 @@ class AlignMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @return array
 	 */
-	private function getMacroParams( DOMNode $macro ): array {
+	private function getMacroParams( DOMElement $macro ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				$params[$paramName] = $childNode->nodeValue;
 			}
@@ -80,11 +79,11 @@ class AlignMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 * @return void
 	 */
-	private function macroBody( DOMNode $macro, DOMElement $macroReplacement ): void {
+	private function macroBody( DOMElement $macro, DOMElement $macroReplacement ): void {
 		foreach ( $macro->childNodes as $childNode ) {
 			if ( $childNode->nodeName === 'ac:rich-text-body' ) {
 				foreach ( $childNode->childNodes as $node ) {

--- a/src/Converter/Processor/AnchorLink.php
+++ b/src/Converter/Processor/AnchorLink.php
@@ -4,7 +4,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMDocument;
 use DOMElement;
-use DOMNode;
 
 class AnchorLink extends LinkProcessorBase {
 
@@ -41,10 +40,11 @@ class AnchorLink extends LinkProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node The ac:link element carrying the ac:anchor attribute.
+	 * @param DOMElement $node The ac:link element carrying the ac:anchor attribute.
+	 *
 	 * @return void
 	 */
-	protected function doProcessLink( DOMNode $node ): void {
+	protected function doProcessLink( DOMElement $node ): void {
 		if ( !$node instanceof DOMElement ) {
 			return;
 		}

--- a/src/Converter/Processor/AnchorMacro.php
+++ b/src/Converter/Processor/AnchorMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 class AnchorMacro extends StructuredMacroProcessorBase {
 
@@ -15,11 +15,14 @@ class AnchorMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$anchorName = '';
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter'
+			if ( $childNode instanceof DOMElement
+				&& $childNode->nodeName === 'ac:parameter'
 				&& $childNode->getAttribute( 'ac:name' ) === '' ) {
 				$anchorName = trim( $childNode->nodeValue );
 				break;

--- a/src/Converter/Processor/AttachmentLink.php
+++ b/src/Converter/Processor/AttachmentLink.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Utility\FilenameResolver;
 
 class AttachmentLink extends LinkProcessorBase {
@@ -17,49 +16,47 @@ class AttachmentLink extends LinkProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return void
 	 */
-	protected function doProcessLink( DOMNode $node ): void {
-		if ( $node instanceof DOMElement ) {
-			$riFilename = $node->getAttribute( 'ri:filename' );
-			$spaceId = $this->ensureSpaceId( $node ) ?? 0;
-			// TODO: Log if spaceId is null, but we should be able to
-			// resolve the filename without spaceId as well, so we can continue processing
+	protected function doProcessLink( DOMElement $node ): void {
+		$riFilename = $node->getAttribute( 'ri:filename' );
+		$spaceId = $this->ensureSpaceId( $node ) ?? 0;
+		// TODO: Log if spaceId is null, but we should be able to
+		// resolve the filename without spaceId as well, so we can continue processing
 
-			$nestedPageEl = $node->getElementsByTagName( 'page' )->item( 0 );
+		$nestedPageEl = $node->getElementsByTagName( 'page' )->item( 0 );
 
-			$rawPageTitle = $this->rawPageTitle;
-			if ( $nestedPageEl instanceof DOMElement ) {
-				$rawPageTitle = $nestedPageEl->getAttribute( 'ri:content-title' );
-			}
-
-			$filenameResolver = new FilenameResolver( $this->dataLookup, $this->migrationConfig );
-			[ 'title' => $targetFilename, 'isBroken' => $isBrokenLink ] =
-				$filenameResolver->resolve( $spaceId, $rawPageTitle, $riFilename );
-
-			$linkParts = [ $targetFilename ];
-			$this->getLinkBody( $node, $linkParts );
-
-			$replacement = $this->getBrokenLinkReplacement();
-
-			if ( !empty( $linkParts ) ) {
-				$replacement = $this->makeLink( $linkParts );
-			}
-
-			if ( $isBrokenLink ) {
-				$replacement .= '[[Category:Broken_attachment_link]]';
-			}
-
-			$this->replaceLink( $node, $replacement );
+		$rawPageTitle = $this->rawPageTitle;
+		if ( $nestedPageEl instanceof DOMElement ) {
+			$rawPageTitle = $nestedPageEl->getAttribute( 'ri:content-title' );
 		}
+
+		$filenameResolver = new FilenameResolver( $this->dataLookup, $this->migrationConfig );
+		[ 'title' => $targetFilename, 'isBroken' => $isBrokenLink ] =
+			$filenameResolver->resolve( $spaceId, $rawPageTitle, $riFilename );
+
+		$linkParts = [ $targetFilename ];
+		$this->getLinkBody( $node, $linkParts );
+
+		$replacement = $this->getBrokenLinkReplacement();
+
+		if ( !empty( $linkParts ) ) {
+			$replacement = $this->makeLink( $linkParts );
+		}
+
+		if ( $isBrokenLink ) {
+			$replacement .= '[[Category:Broken_attachment_link]]';
+		}
+
+		$this->replaceLink( $node, $replacement );
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return int|null
 	 */
-	private function ensureSpaceId( DOMNode $node ): ?int {
+	private function ensureSpaceId( DOMElement $node ): ?int {
 		$spaceId = $this->currentSpaceId;
 		$pageNode = $node->getElementsByTagName( 'page' )->item( 0 );
 

--- a/src/Converter/Processor/AttachmentsMacro.php
+++ b/src/Converter/Processor/AttachmentsMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 class AttachmentsMacro extends StructuredMacroProcessorBase {
 
@@ -15,8 +15,10 @@ class AttachmentsMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$attachmentsEl = $node->ownerDocument->createElement( 'attachments' );
 		$attachmentsEl->appendChild( $node->ownerDocument->createTextNode( '' ) );
 		$node->parentNode->replaceChild( $attachmentsEl, $node );

--- a/src/Converter/Processor/ChildrenMacro.php
+++ b/src/Converter/Processor/ChildrenMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use Exception;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 
@@ -31,7 +31,7 @@ class ChildrenMacro extends StructuredMacroProcessorBase {
 	 * @inheritDoc
 	 * @throws Exception
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$isBroken = false;
 
 		$params = $this->processParams( $node );
@@ -71,16 +71,16 @@ class ChildrenMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return array
 	 * @throws Exception
 	 */
-	private function processParams( DOMNode $node ): array {
+	private function processParams( DOMElement $node ): array {
 		$params = [];
 
 		foreach ( $node->childNodes as $paramNode ) {
-			if ( $paramNode->nodeName !== 'ac:parameter' ) {
+			if ( !( $paramNode instanceof DOMElement ) || $paramNode->nodeName !== 'ac:parameter' ) {
 				continue;
 			}
 
@@ -112,18 +112,21 @@ class ChildrenMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $paramNode
+	 * @param DOMElement $paramNode
 	 *
 	 * @return string|null
 	 * @throws Exception
 	 */
-	private function processPageParam( DOMNode $paramNode ): ?string {
+	private function processPageParam( DOMElement $paramNode ): ?string {
 		if ( $paramNode->hasChildnodes() ) {
 			foreach ( $paramNode->childNodes as $childNode ) {
-				if ( $childNode->nodeName === 'ac:link' ) {
+				if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:link' ) {
 					$pageLinks = $childNode->getElementsByTagname( 'page' );
 					if ( count( $pageLinks ) > 0 ) {
 						$pageLink = $pageLinks->item( 0 );
+						if ( !( $pageLink instanceof DOMElement ) ) {
+							continue;
+						}
 						$resolved = $this->findChildWikiTitle( $pageLink );
 
 						if ( $resolved !== null ) {
@@ -143,12 +146,12 @@ class ChildrenMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $pageLink
+	 * @param DOMElement $pageLink
 	 *
 	 * @return string|null
 	 * @throws Exception
 	 */
-	private function findChildWikiTitle( DOMNode $pageLink ): ?string {
+	private function findChildWikiTitle( DOMElement $pageLink ): ?string {
 		if ( !$pageLink->hasAttribute( 'ri:content-title' ) ) {
 			return null;
 		}

--- a/src/Converter/Processor/CodeMacro.php
+++ b/src/Converter/Processor/CodeMacro.php
@@ -2,8 +2,8 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
+use DOMElement;
 use DOMException;
-use DOMNode;
 
 /**
  * Unfortunately `pandoc` eats <syntaxhighlight> tags.
@@ -24,7 +24,7 @@ class CodeMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
 		$macroReplacement->setAttribute( 'class', 'PRESERVESYNTAXHIGHLIGHT' );
 
@@ -35,13 +35,13 @@ class CodeMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
-	 * @param DOMNode $replacementNode
+	 * @param DOMElement $node
+	 * @param DOMElement $replacementNode
 	 *
 	 * @return void
 	 * @throws DOMException
 	 */
-	private function processParamElements( DOMNode $node, DOMNode $replacementNode ): void {
+	private function processParamElements( DOMElement $node, DOMElement $replacementNode ): void {
 		$paramEls = $node->getElementsByTagName( 'parameter' );
 		foreach ( $paramEls as $paramEl ) {
 			$paramName = $paramEl->getAttribute( 'ac:name' );
@@ -65,11 +65,11 @@ class CodeMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
-	 * @param DOMNode $replacementNode
+	 * @param DOMElement $node
+	 * @param DOMElement $replacementNode
 	 * @return void
 	 */
-	private function processPlainTextBody( DOMNode $node, DOMNode $replacementNode ): void {
+	private function processPlainTextBody( DOMElement $node, DOMElement $replacementNode ): void {
 		$hasPlaintextEls = false;
 		$plaintextEls = $node->getElementsByTagName( 'plain-text-body' );
 		foreach ( $plaintextEls as $plaintextEl ) {

--- a/src/Converter/Processor/ContentByLabelMacro.php
+++ b/src/Converter/Processor/ContentByLabelMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MigrateConfluence\Utility\CQLParser;
 
 class ContentByLabelMacro extends StructuredMacroProcessorBase {
@@ -22,11 +22,13 @@ class ContentByLabelMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$paramNodes = [];
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramNodes[] = $childNode;
 			}
 		}

--- a/src/Converter/Processor/CreateFromTemplateMacro.php
+++ b/src/Converter/Processor/CreateFromTemplateMacro.php
@@ -4,7 +4,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMDocument;
 use DOMElement;
-use DOMNode;
 use HalloWelt\MediaWiki\Lib\WikiText\Template;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
@@ -88,16 +87,13 @@ class CreateFromTemplateMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
 	 */
-	private function doProcessMacro( DOMNode $node ): void {
+	private function doProcessMacro( DOMElement $node ): void {
 		$params = $this->getParams( $node );
-		$macroId = '';
-		if ( $node instanceof DOMElement ) {
-			$macroId = $node->getAttribute( 'ac:macro-id' );
-		}
+		$macroId = $node->getAttribute( 'ac:macro-id' );
 		$templateTitle = $this->findTemplateTitle( $params );
 		$errorMessage = $this->getResolutionError( $params, $templateTitle );
 
@@ -173,11 +169,11 @@ class CreateFromTemplateMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return array
 	 */
-	private function getParams( DOMNode $node ): array {
+	private function getParams( DOMElement $node ): array {
 		$params = [];
 
 		// Extract scalar parameters — only direct children, not those inside nested macros.

--- a/src/Converter/Processor/DrawioMacro.php
+++ b/src/Converter/Processor/DrawioMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MigrateConfluence\Utility\ConversionDataWriter;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\DrawIOFileHandler;
@@ -54,7 +54,7 @@ class DrawioMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->getMacroParams( $node );
 
 		if ( isset( $params['diagramName'] ) ) {
@@ -89,14 +89,14 @@ class DrawioMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 *
 	 * @return array
 	 */
-	private function getMacroParams( DOMNode $macro ): array {
+	private function getMacroParams( DOMElement $macro ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 
 				if ( $paramName === '' ) {

--- a/src/Converter/Processor/Emoticon.php
+++ b/src/Converter/Processor/Emoticon.php
@@ -3,7 +3,7 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMDocument;
-use DOMNode;
+use DOMElement;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 class Emoticon implements IProcessor {
@@ -46,11 +46,11 @@ class Emoticon implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return string
 	 */
-	private function getReplacement( DOMNode $node ): string {
+	private function getReplacement( DOMElement $node ): string {
 		$name = $node->getAttribute( 'ac:name' );
 
 		if ( $name === 'blue-star' ) {
@@ -65,11 +65,11 @@ class Emoticon implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @param string $replacement
 	 * @return void
 	 */
-	protected function replaceEmoticon( DOMNode $node, string $replacement ): void {
+	protected function replaceEmoticon( DOMElement $node, string $replacement ): void {
 		if ( !empty( $replacement ) ) {
 			$node->parentNode->replaceChild(
 				$node->ownerDocument->createTextNode( $replacement ),

--- a/src/Converter/Processor/ExcerptIncludeMacro.php
+++ b/src/Converter/Processor/ExcerptIncludeMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 class ExcerptIncludeMacro extends IncludeMacro {
 
@@ -21,16 +21,18 @@ class ExcerptIncludeMacro extends IncludeMacro {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$this->parameters = [];
 		$parameterEls = $node->getElementsByTagName( 'parameter' );
 		foreach ( $parameterEls as $parameterEl ) {
-			$paramName = trim( $parameterEl->getAttribute( 'ac:name' ) ?? '' );
+			$paramName = trim( $parameterEl->getAttribute( 'ac:name' ) );
 			if ( empty( $paramName ) ) {
 				continue;
 			}
-			$paramValue = trim( $parameterEl->textContent ?? '' );
+			$paramValue = trim( $parameterEl->textContent );
 			$this->parameters[$paramName] = $paramValue;
 		}
 		parent::doProcessMacro( $node );

--- a/src/Converter/Processor/ExcerptMacro.php
+++ b/src/Converter/Processor/ExcerptMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 /**
  * Converts the Confluence excerpt macro to a BlueSpice <excerpt-block> element.
@@ -26,20 +26,21 @@ class ExcerptMacro extends StructuredMacroProcessorBase {
 	 * format. To preserve the tag, we insert text placeholders around the content here and
 	 * restore the actual <excerpt-block> tag in the RestoreExcerptBlock postprocessor.
 	 * Placeholders use pipe-separated values to avoid HTML attribute quote encoding issues.
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroId = $node->getAttribute( 'ac:macro-id' );
 		$hidden = 'false';
 
 		// TODO: Set to false as soon as the excerpt extension is available
-		$isBroken = true;
 
 		if ( empty( $macroId ) ) {
-			$isBroken = true;
 		}
 
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter'
+			if ( $childNode instanceof DOMElement
+				&& $childNode->nodeName === 'ac:parameter'
 				&& $childNode->getAttribute( 'ac:name' ) === 'hidden' ) {
 				$hidden = trim( $childNode->nodeValue );
 				break;
@@ -64,12 +65,10 @@ class ExcerptMacro extends StructuredMacroProcessorBase {
 		$closeTag = $node->ownerDocument->createTextNode( '#####EXCERPTBLOCKCLOSE#####' );
 		$parent->insertBefore( $closeTag, $node );
 
-		if ( $isBroken ) {
-			$brokenCategory = $node->ownerDocument->createTextNode(
+		$brokenCategory = $node->ownerDocument->createTextNode(
 				$this->getBrokenMacroCategory()
 			);
 			$parent->insertBefore( $brokenCategory, $node );
-		}
 
 		$parent->removeChild( $node );
 	}

--- a/src/Converter/Processor/GalleryMacro.php
+++ b/src/Converter/Processor/GalleryMacro.php
@@ -2,6 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
+use DOMElement;
 use DOMNode;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\FilenameResolver;
@@ -56,7 +57,7 @@ class GalleryMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$this->filenameResolver = new FilenameResolver( $this->dataLookup, $this->config );
 
 		$macroName = $node->getAttribute( 'ac:name' );
@@ -263,10 +264,10 @@ class GalleryMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @return DOMNode[]
 	 */
-	private function getBodyImages( DOMNode $macro ): array {
+	private function getBodyImages( DOMElement $macro ): array {
 		$images = [];
 		foreach ( $macro->childNodes as $childNode ) {
 			if ( $childNode->nodeName === 'ac:image' ) {
@@ -287,9 +288,9 @@ class GalleryMacro extends StructuredMacroProcessorBase {
 			$isUrl = false;
 
 			foreach ( $imageNode->childNodes as $child ) {
-				if ( $child->nodeName === 'ri:attachment' ) {
+				if ( $child instanceof DOMElement && $child->nodeName === 'ri:attachment' ) {
 					$attachment = $child;
-				} elseif ( $child->nodeName === 'ri:url' ) {
+				} elseif ( $child instanceof DOMElement && $child->nodeName === 'ri:url' ) {
 					$isUrl = true;
 				}
 			}
@@ -309,7 +310,7 @@ class GalleryMacro extends StructuredMacroProcessorBase {
 
 			$page = null;
 			foreach ( $attachment->childNodes as $child ) {
-				if ( $child->nodeName === 'ri:page' ) {
+				if ( $child instanceof DOMElement && $child->nodeName === 'ri:page' ) {
 					$page = $child;
 					break;
 				}
@@ -352,14 +353,14 @@ class GalleryMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 *
 	 * @return array
 	 */
-	private function getMacroParams( DOMNode $macro ): array {
+	private function getMacroParams( DOMElement $macro ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				if ( $paramName === '' ) {
 					continue;

--- a/src/Converter/Processor/GliffyMacro.php
+++ b/src/Converter/Processor/GliffyMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\PipeToDB;
 
@@ -33,7 +33,7 @@ class GliffyMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->getMacroParams( $node );
 
 		if ( isset( $params['name'] ) ) {
@@ -118,14 +118,14 @@ class GliffyMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 *
 	 * @return array
 	 */
-	private function getMacroParams( DOMNode $macro ): array {
+	private function getMacroParams( DOMElement $macro ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				if ( $paramName === '' ) {
 					continue;

--- a/src/Converter/Processor/Image.php
+++ b/src/Converter/Processor/Image.php
@@ -110,7 +110,7 @@ class Image implements IProcessor {
 	 *
 	 * @return array
 	 */
-	private function getImageAttributes( DOMNode $node ): array {
+	private function getImageAttributes( DOMElement $node ): array {
 		$attributes = [];
 		$width = '';
 		$height = '';
@@ -436,11 +436,11 @@ class Image implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return bool
 	 */
-	private function isImageWithPageLink( DOMNode $node ): bool {
+	private function isImageWithPageLink( DOMElement $node ): bool {
 		if ( $node->parentNode->nodeName === 'ac:link-body' ) {
 			return true;
 		}
@@ -468,11 +468,11 @@ class Image implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return bool
 	 */
-	private function isImageWithExternalLink( DOMNode $node ): bool {
+	private function isImageWithExternalLink( DOMElement $node ): bool {
 		if ( $node->parentNode->nodeName !== 'a' ) {
 			return false;
 		}

--- a/src/Converter/Processor/ImagePageLinkHelper.php
+++ b/src/Converter/Processor/ImagePageLinkHelper.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 
 class ImagePageLinkHelper {
@@ -44,11 +43,11 @@ class ImagePageLinkHelper {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return string
 	 */
-	public function getLinkTarget( DOMNode $node ): string {
-		if ( $node instanceof DOMElement && $node->nodeName === 'ac:link' ) {
+	public function getLinkTarget( DOMElement $node ): string {
+		if ( $node->nodeName === 'ac:link' ) {
 			$page = $node->getElementsByTagName( 'page' )->item( 0 );
 
 			if ( $page instanceof DOMElement ) {
@@ -79,10 +78,10 @@ class ImagePageLinkHelper {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return int
 	 */
-	private function ensureSpaceId( DOMNode $node ): int {
+	private function ensureSpaceId( DOMElement $node ): int {
 		$spaceId = $this->currentSpaceId;
 		$this->spaceKey = $node->getAttribute( 'ri:space-key' );
 		if ( !empty( $this->spaceKey ) ) {

--- a/src/Converter/Processor/IncludeMacro.php
+++ b/src/Converter/Processor/IncludeMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MediaWiki\Lib\Migration\InvalidTitleException;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 
@@ -24,9 +24,9 @@ class IncludeMacro extends StructuredMacroProcessorBase {
 	protected string $mediaWikiPageName = '';
 
 	/**
-	 * @var DOMNode|null
+	 * @var DOMElement|null
 	 */
-	protected ?DOMNode $currentNode = null;
+	protected ?DOMElement $currentNode = null;
 
 	/**
 	 * @param DBConversionDataLookup $dataLookup
@@ -47,8 +47,10 @@ class IncludeMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$this->currentNode = $node;
 		$this->setMediaWikiPageName();
 
@@ -76,7 +78,7 @@ class IncludeMacro extends StructuredMacroProcessorBase {
 	 */
 	private function setMediaWikiPageName(): void {
 		$pageEl = $this->currentNode->getElementsByTagName( 'page' )->item( 0 );
-		if ( $pageEl === null ) {
+		if ( !( $pageEl instanceof DOMElement ) ) {
 			return;
 		}
 		$targetPageName = $pageEl->getAttribute( 'ri:content-title' );

--- a/src/Converter/Processor/JiraMacro.php
+++ b/src/Converter/Processor/JiraMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MediaWiki\Lib\WikiText\Template;
 
 class JiraMacro extends StructuredMacroProcessorBase {
@@ -17,7 +17,7 @@ class JiraMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->readParams( $node );
 
 		$hasKey = isset( $params['key'] ) && $params['key'] !== '';
@@ -54,13 +54,13 @@ class JiraMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return array
 	 */
-	protected function readParams( DOMNode $node ): array {
+	protected function readParams( DOMElement $node ): array {
 		$params = [];
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				$paramValue = $childNode->nodeValue;
 				$params[$paramName] = $paramValue;

--- a/src/Converter/Processor/LinkProcessorBase.php
+++ b/src/Converter/Processor/LinkProcessorBase.php
@@ -56,10 +56,11 @@ abstract class LinkProcessorBase implements IProcessor {
 	abstract protected function getProcessableNodeName(): string;
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
+	 *
 	 * @return void
 	 */
-	abstract protected function doProcessLink( DOMNode $node ): void;
+	abstract protected function doProcessLink( DOMElement $node ): void;
 
 	/**
 	 * @inheritDoc
@@ -118,20 +119,24 @@ abstract class LinkProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @param array &$linkParts
 	 *
 	 * @return void
 	 */
-	protected function getLinkBody( DOMNode $node, array &$linkParts ): void {
+	protected function getLinkBody( DOMElement $node, array &$linkParts ): void {
 		// Let's see if there is a description Text
+		$parent = $node->parentNode;
+		if ( !( $parent instanceof DOMElement ) ) {
+			return;
+		}
 		// HTML Content
-		$linkBodys = $node->parentNode->getElementsByTagName( 'link-body' );
+		$linkBodys = $parent->getElementsByTagName( 'link-body' );
 		$linkBody = $linkBodys->item( 0 );
 
 		if ( $linkBody instanceof DOMElement === false ) {
 			// CDATA Content
-			$linkBodys = $node->parentNode->getElementsByTagName( 'plain-text-link-body' );
+			$linkBodys = $parent->getElementsByTagName( 'plain-text-link-body' );
 			$linkBody = $linkBodys->item( 0 );
 		}
 

--- a/src/Converter/Processor/LocalTabGroupMacro.php
+++ b/src/Converter/Processor/LocalTabGroupMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 	/**
 	 *
@@ -27,8 +27,10 @@ class LocalTabGroupMacro extends MacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
 		$macroReplacement->setAttribute( 'class', "ac-localtabgroup" );
 

--- a/src/Converter/Processor/LocalTabMacro.php
+++ b/src/Converter/Processor/LocalTabMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 	/**
 	 *
@@ -27,8 +27,10 @@ class LocalTabMacro extends MacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->getMacroParams( $node );
 
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );

--- a/src/Converter/Processor/LoremIpsumMacro.php
+++ b/src/Converter/Processor/LoremIpsumMacro.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 
 /**
  * <ac:structured-macro ac:name="loremipsum">
@@ -32,7 +31,7 @@ class LoremIpsumMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$paragraphs = 0;
 
 		foreach ( $node->childNodes as $childNode ) {
@@ -137,7 +136,7 @@ class LoremIpsumMacro extends StructuredMacroProcessorBase {
 			] ),
 		];
 
-		$index = $paragraph % 10;
+		$index = ( ( $paragraph % 10 ) + 10 ) % 10;
 		return $paragraphs[$index];
 	}
 }

--- a/src/Converter/Processor/MacroProcessorBase.php
+++ b/src/Converter/Processor/MacroProcessorBase.php
@@ -5,7 +5,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 use DOMDocument;
 use DOMElement;
 use DOMException;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 abstract class MacroProcessorBase implements IProcessor {
@@ -37,12 +36,12 @@ abstract class MacroProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
 	 * @throws DOMException
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroName = $node->getAttribute( 'ac:name' );
 
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
@@ -53,14 +52,14 @@ abstract class MacroProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 *
 	 * @return array
 	 */
-	protected function getMacroParams( DOMNode $macro ): array {
+	protected function getMacroParams( DOMElement $macro ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				if ( $paramName === '' ) {
 					continue;
@@ -73,12 +72,12 @@ abstract class MacroProcessorBase implements IProcessor {
 
 	/**
 	 *
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 *
 	 * @return void
 	 */
-	protected function macroParams( DOMNode $macro, DOMElement $macroReplacement ): void {
+	protected function macroParams( DOMElement $macro, DOMElement $macroReplacement ): void {
 		$params = $this->getMacroParams( $macro );
 
 		if ( !empty( $params ) ) {
@@ -87,12 +86,12 @@ abstract class MacroProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 *
 	 * @return void
 	 */
-	protected function macroBody( DOMNode $macro, DOMElement $macroReplacement ): void {
+	protected function macroBody( DOMElement $macro, DOMElement $macroReplacement ): void {
 		foreach ( $macro->childNodes as $childNode ) {
 			if ( $childNode->nodeName === 'ac:rich-text-body' ) {
 				foreach ( $childNode->childNodes as $node ) {

--- a/src/Converter/Processor/MarkdownMacro.php
+++ b/src/Converter/Processor/MarkdownMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 class MarkdownMacro extends StructuredMacroProcessorBase {
 
@@ -15,8 +15,10 @@ class MarkdownMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$brokenMacro = false;
 
 		$markdownContent = '';

--- a/src/Converter/Processor/NoFormatMacro.php
+++ b/src/Converter/Processor/NoFormatMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 /**
  * Unfortunately `pandoc` eats <syntaxhighlight> tags.
@@ -23,7 +23,7 @@ class NoFormatMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'pre' );
 		$macroReplacement->setAttribute( 'class', 'noformat' );
 
@@ -34,12 +34,12 @@ class NoFormatMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
-	 * @param DOMNode $replacementNode
+	 * @param DOMElement $node
+	 * @param DOMElement $replacementNode
 	 *
 	 * @return void
 	 */
-	private function processParamElements( DOMNode $node, DOMNode $replacementNode ): void {
+	private function processParamElements( DOMElement $node, DOMElement $replacementNode ): void {
 		$paramEls = $node->getElementsByTagName( 'parameter' );
 		foreach ( $paramEls as $paramEl ) {
 			$paramName = $paramEl->getAttribute( 'ac:name' );
@@ -51,12 +51,12 @@ class NoFormatMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
-	 * @param DOMNode $replacementNode
+	 * @param DOMElement $node
+	 * @param DOMElement $replacementNode
 	 *
 	 * @return void
 	 */
-	private function processPlainTextBody( DOMNode $node, DOMNode $replacementNode ): void {
+	private function processPlainTextBody( DOMElement $node, DOMElement $replacementNode ): void {
 		$hasPlaintextEls = false;
 		$plaintextEls = $node->getElementsByTagName( 'plain-text-body' );
 		foreach ( $plaintextEls as $plaintextEl ) {

--- a/src/Converter/Processor/PageLink.php
+++ b/src/Converter/Processor/PageLink.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 use HalloWelt\MediaWiki\Lib\Migration\InvalidTitleException;
 use HalloWelt\MediaWiki\Lib\Migration\TitleBuilder as GenericTitleBuilder;
 
@@ -21,12 +20,12 @@ class PageLink extends LinkProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
 	 * @throws InvalidTitleException
 	 */
-	protected function doProcessLink( DOMNode $node ): void {
+	protected function doProcessLink( DOMElement $node ): void {
 		if ( !( $node instanceof DOMElement ) ) {
 			return;
 		}
@@ -59,11 +58,11 @@ class PageLink extends LinkProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return int
 	 */
-	private function ensureSpaceId( DOMNode $node ): int {
+	private function ensureSpaceId( DOMElement $node ): int {
 		$spaceId = $this->currentSpaceId;
 		$this->spaceKey = $node->getAttribute( 'ri:space-key' );
 

--- a/src/Converter/Processor/PageTreeMacro.php
+++ b/src/Converter/Processor/PageTreeMacro.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 use Exception;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 
@@ -40,7 +39,7 @@ class PageTreeMacro extends StructuredMacroProcessorBase {
 	 * @inheritDoc
 	 * @throws Exception
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$this->macroParams( $node );
 		$brokenMacro = false;
 		if ( isset( $this->params['broken-macro'] ) ) {
@@ -66,15 +65,15 @@ class PageTreeMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 *
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	private function macroParams( DOMNode $macro ): void {
+	private function macroParams( DOMElement $macro ): void {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				if ( $paramName === 'root' ) {
 					// page link
@@ -161,20 +160,12 @@ class PageTreeMacro extends StructuredMacroProcessorBase {
 				$params['content-title'] = '';
 				// current WikiTitle
 				$targetTitle = $this->wikiTitle;
-				if ( $targetTitle === null ) {
-					$params['broken-macro'] = true;
-					break;
-				}
 				$params['content-title'] = $targetTitle;
 				break;
 			case '@parent':
 				$params['content-title'] = '';
 				// parent of current PageTitle
 				$targetTitle = $this->wikiTitle;
-				if ( $targetTitle === null ) {
-					$params['broken-macro'] = true;
-					break;
-				}
 				$currentPageParts = explode( '/', $targetTitle );
 				if ( count( $currentPageParts ) > 1 ) {
 					array_pop( $currentPageParts );

--- a/src/Converter/Processor/RecentlyUpdatedMacro.php
+++ b/src/Converter/Processor/RecentlyUpdatedMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 
 class RecentlyUpdatedMacro extends StructuredMacroProcessorBase {
 
@@ -22,8 +22,10 @@ class RecentlyUpdatedMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$namespace = '';
 		$titleParts = explode( ':', $this->wikiTitle, 2 );
 		if ( count( $titleParts ) === 2 ) {

--- a/src/Converter/Processor/SpaceDetailsMacro.php
+++ b/src/Converter/Processor/SpaceDetailsMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MediaWiki\Lib\WikiText\Template;
 
 class SpaceDetailsMacro extends StructuredMacroProcessorBase {
@@ -18,7 +18,7 @@ class SpaceDetailsMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->readParams( $node );
 		$wikitextTemplate = new Template( $this->getWikiTextTemplateName(), $params );
 		$wikitextTemplate->setRenderFormatted( false );
@@ -35,15 +35,15 @@ class SpaceDetailsMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return array
 	 */
-	protected function readParams( DOMNode $node ): array {
+	protected function readParams( DOMElement $node ): array {
 		$params = [];
 		$params['width'] = '100%';
 
 		foreach ( $node->childNodes as $paramNode ) {
-			if ( $paramNode->nodeName === 'ac:parameter' ) {
+			if ( $paramNode instanceof DOMElement && $paramNode->nodeName === 'ac:parameter' ) {
 				$paramName = $paramNode->getAttribute( 'ac:name' );
 				if ( $paramName === 'width' ) {
 					if ( trim( $paramNode->nodeValue ) !== '' ) {

--- a/src/Converter/Processor/StructuredMacroProcessorBase.php
+++ b/src/Converter/Processor/StructuredMacroProcessorBase.php
@@ -5,7 +5,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 use DOMDocument;
 use DOMElement;
 use DOMException;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 abstract class StructuredMacroProcessorBase implements IProcessor {
@@ -37,12 +36,12 @@ abstract class StructuredMacroProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
 	 * @throws DOMException
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroName = $node->getAttribute( 'ac:name' );
 
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
@@ -54,15 +53,15 @@ abstract class StructuredMacroProcessorBase implements IProcessor {
 
 	/**
 	 *
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 *
 	 * @return void
 	 */
-	private function macroParams( DOMNode $macro, DOMElement $macroReplacement ): void {
+	private function macroParams( DOMElement $macro, DOMElement $macroReplacement ): void {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramName = $childNode->getAttribute( 'ac:name' );
 				if ( $paramName === '' ) {
 					continue;
@@ -77,12 +76,12 @@ abstract class StructuredMacroProcessorBase implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 *
 	 * @return void
 	 */
-	private function macroBody( DOMNode $macro, DOMElement $macroReplacement ): void {
+	private function macroBody( DOMElement $macro, DOMElement $macroReplacement ): void {
 		foreach ( $macro->childNodes as $childNode ) {
 			if ( $childNode->nodeName === 'ac:rich-text-body' ) {
 				foreach ( $childNode->childNodes as $node ) {

--- a/src/Converter/Processor/TaskListMacro.php
+++ b/src/Converter/Processor/TaskListMacro.php
@@ -5,7 +5,6 @@ namespace HalloWelt\MigrateConfluence\Converter\Processor;
 use DOMDocument;
 use DOMElement;
 use DOMException;
-use DOMNode;
 use HalloWelt\MigrateConfluence\Converter\IProcessor;
 
 /**
@@ -44,12 +43,13 @@ class TaskListMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
+	 *
 	 * @throws DOMException
 	 */
-	protected function doProcessTask( DOMNode $node ): void {
+	protected function doProcessTask( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'task-replacement' );
 
 		foreach ( $node->childNodes as $childNode ) {
@@ -69,13 +69,11 @@ class TaskListMacro implements IProcessor {
 			}
 		}
 
-		if ( $node instanceof DOMElement ) {
-			$txt = $macroReplacement->ownerDocument->createTextNode( "\n[x] " );
-			if ( $macroReplacement->getAttribute( 'data-task-status' ) === 'incomplete' ) {
-				$txt = $macroReplacement->ownerDocument->createTextNode( "\n[] " );
-			}
-			$macroReplacement->prepend( $txt );
+		$txt = $macroReplacement->ownerDocument->createTextNode( "\n[x] " );
+		if ( $macroReplacement->getAttribute( 'data-task-status' ) === 'incomplete' ) {
+			$txt = $macroReplacement->ownerDocument->createTextNode( "\n[] " );
 		}
+		$macroReplacement->prepend( $txt );
 
 		$node->parentNode->replaceChild( $macroReplacement, $node );
 	}
@@ -102,12 +100,13 @@ class TaskListMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
+	 *
 	 * @throws DOMException
 	 */
-	protected function doProcessTaskBody( DOMNode $node ): void {
+	protected function doProcessTaskBody( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'task-body-replacement' );
 
 		foreach ( $node->childNodes as $childNode ) {
@@ -124,17 +123,15 @@ class TaskListMacro implements IProcessor {
 			$macroReplacement->appendChild( $newNode );
 		}
 
-		if ( $node instanceof DOMElement ) {
-			$ol = $node->getElementsByTagName( 'ol' );
-			$ul = $node->getElementsByTagName( 'ul' );
-			$div = $node->getElementsByTagName( 'div' );
+		$ol = $node->getElementsByTagName( 'ol' );
+		$ul = $node->getElementsByTagName( 'ul' );
+		$div = $node->getElementsByTagName( 'div' );
 
-			if ( count( $ol ) > 0 || count( $ul ) > 0 || count( $div ) > 0 ) {
-				$brokenNode = $node->ownerDocument->createTextNode(
-					'[[Category:Broken_macro/task]]'
-				);
-				$macroReplacement->appendChild( $brokenNode );
-			}
+		if ( count( $ol ) > 0 || count( $ul ) > 0 || count( $div ) > 0 ) {
+			$brokenNode = $node->ownerDocument->createTextNode(
+				'[[Category:Broken_macro/task]]'
+			);
+			$macroReplacement->appendChild( $brokenNode );
 		}
 		$brokenNode = $node->ownerDocument->createElement( 'br' );
 		$macroReplacement->appendChild( $brokenNode );
@@ -164,12 +161,13 @@ class TaskListMacro implements IProcessor {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return void
+	 *
 	 * @throws DOMException
 	 */
-	protected function doProcessTaskList( DOMNode $node ): void {
+	protected function doProcessTaskList( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
 		$macroReplacement->setAttribute( 'class', 'ac-task-list' );
 

--- a/src/Converter/Processor/TasksReportMacro.php
+++ b/src/Converter/Processor/TasksReportMacro.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 use DOMText;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 
@@ -29,10 +28,10 @@ class TasksReportMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$paramNodes = [];
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
+			if ( $childNode instanceof DOMElement && $childNode->nodeName === 'ac:parameter' ) {
 				$paramNodes[] = $childNode;
 			}
 		}
@@ -101,7 +100,7 @@ class TasksReportMacro extends StructuredMacroProcessorBase {
 	 * @param DOMElement $user
 	 * @return string
 	 */
-	private function findUserName( DOMNode $user ): string {
+	private function findUserName( DOMElement $user ): string {
 		if ( $user->nodeName !== 'ri:user' ) {
 			return '';
 		}

--- a/src/Converter/Processor/TocMacro.php
+++ b/src/Converter/Processor/TocMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MigrateConfluence\Utility\TocMacroUsage;
 
 class TocMacro extends StructuredMacroProcessorBase {
@@ -24,8 +24,10 @@ class TocMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 * @inheritDoc
+	 *
+	 * @param DOMElement $node
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$this->usage->tocIsUsed();
 
 		$node->parentNode->replaceChild(

--- a/src/Converter/Processor/UserLink.php
+++ b/src/Converter/Processor/UserLink.php
@@ -3,7 +3,6 @@
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
 use DOMElement;
-use DOMNode;
 
 class UserLink extends LinkProcessorBase {
 
@@ -16,40 +15,39 @@ class UserLink extends LinkProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
+	 *
 	 * @return void
 	 */
-	protected function doProcessLink( DOMNode $node ): void {
+	protected function doProcessLink( DOMElement $node ): void {
 		$linkParts = [];
 
-		if ( $node instanceof DOMElement ) {
-			$isBrokenLink = false;
-			$userKey = $node->getAttribute( 'ri:userkey' );
+		$isBrokenLink = false;
+		$userKey = $node->getAttribute( 'ri:userkey' );
 
-			if ( !empty( $userKey ) ) {
-				$username = $this->dataLookup->getUsernameFromUserKey( $userKey ) ?? $userKey;
-				$linkParts[] = 'User:' . $username;
-				$linkParts[] = $username;
-			} else {
-				$linkParts[] = 'NULL';
-				$linkParts[] = 'NULL';
-				$isBrokenLink = true;
-			}
-
-			$this->getLinkBody( $node, $linkParts );
-
-			$replacement = $this->getBrokenLinkReplacement();
-
-			if ( !empty( $linkParts ) ) {
-				$replacement = $this->makeLink( $linkParts );
-			}
-
-			if ( $isBrokenLink ) {
-				$replacement .= '[[Category:Broken_user_link]]';
-			}
-
-			$this->replaceLink( $node, $replacement );
+		if ( !empty( $userKey ) ) {
+			$username = $this->dataLookup->getUsernameFromUserKey( $userKey ) ?? $userKey;
+			$linkParts[] = 'User:' . $username;
+			$linkParts[] = $username;
+		} else {
+			$linkParts[] = 'NULL';
+			$linkParts[] = 'NULL';
+			$isBrokenLink = true;
 		}
+
+		$this->getLinkBody( $node, $linkParts );
+
+		$replacement = $this->getBrokenLinkReplacement();
+
+		if ( !empty( $linkParts ) ) {
+			$replacement = $this->makeLink( $linkParts );
+		}
+
+		if ( $isBrokenLink ) {
+			$replacement .= '[[Category:Broken_user_link]]';
+		}
+
+		$this->replaceLink( $node, $replacement );
 	}
 
 	/**

--- a/src/Converter/Processor/ViewFileMacro.php
+++ b/src/Converter/Processor/ViewFileMacro.php
@@ -2,7 +2,7 @@
 
 namespace HalloWelt\MigrateConfluence\Converter\Processor;
 
-use DOMNode;
+use DOMElement;
 use HalloWelt\MediaWiki\Lib\WikiText\Template;
 use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
 use HalloWelt\MigrateConfluence\Utility\FilenameResolver;
@@ -54,7 +54,7 @@ class ViewFileMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$params = $this->readParams( $node );
 
 		// No ri:filename attribute at all — macro is genuinely broken.
@@ -97,30 +97,32 @@ class ViewFileMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @return array
 	 */
-	protected function readParams( DOMNode $node ): array {
+	protected function readParams( DOMElement $node ): array {
 		$params = [];
 		foreach ( $node->childNodes as $childNode ) {
-			if ( $childNode->nodeName === 'ac:parameter' ) {
-				$paramName = $childNode->getAttribute( 'ac:name' );
-				if ( $paramName === 'name' ) {
-					foreach ( $childNode->childNodes as $attachmentNode ) {
-						if ( $attachmentNode->nodeName === 'ri:attachment' ) {
-							if ( $attachmentNode->hasAttribute( 'ri:filename' ) ) {
-								$params['_riFilename'] = $attachmentNode->getAttribute( 'ri:filename' );
-							}
-							if ( $attachmentNode->hasAttribute( 'ri:version-at-save' ) ) {
-								$params['version-at-save'] = $attachmentNode
-									->getAttribute( 'ri:version-at-save' );
-							}
-						}
+			if ( !( $childNode instanceof DOMElement ) || $childNode->nodeName !== 'ac:parameter' ) {
+				continue;
+			}
+			$paramName = $childNode->getAttribute( 'ac:name' );
+			if ( $paramName === 'name' ) {
+				foreach ( $childNode->childNodes as $attachmentNode ) {
+					if ( !( $attachmentNode instanceof DOMElement ) || $attachmentNode->nodeName !== 'ri:attachment' ) {
+						continue;
 					}
-				} else {
-					$paramValue = $childNode->nodeValue;
-					$params[$paramName] = $paramValue;
+					if ( $attachmentNode->hasAttribute( 'ri:filename' ) ) {
+						$params['_riFilename'] = $attachmentNode->getAttribute( 'ri:filename' );
+					}
+					if ( $attachmentNode->hasAttribute( 'ri:version-at-save' ) ) {
+						$params['version-at-save'] = $attachmentNode
+							->getAttribute( 'ri:version-at-save' );
+					}
 				}
+			} else {
+				$paramValue = $childNode->nodeValue;
+				$params[$paramName] = $paramValue;
 			}
 		}
 		return $params;

--- a/src/Converter/Processor/WidgetMacro.php
+++ b/src/Converter/Processor/WidgetMacro.php
@@ -20,7 +20,7 @@ class WidgetMacro extends StructuredMacroProcessorBase {
 	/**
 	 * @inheritDoc
 	 */
-	protected function doProcessMacro( DOMNode $node ): void {
+	protected function doProcessMacro( DOMElement $node ): void {
 		$macroReplacement = $node->ownerDocument->createElement( 'div' );
 		$macroReplacement->setAttribute( 'class', "ac-widget" );
 
@@ -35,12 +35,12 @@ class WidgetMacro extends StructuredMacroProcessorBase {
 
 	/**
 	 *
-	 * @param DOMNode $macro
+	 * @param DOMElement $macro
 	 * @param DOMElement $macroReplacement
 	 *
 	 * @return array
 	 */
-	private function macroParams( DOMNode $macro, DOMElement $macroReplacement ): array {
+	private function macroParams( DOMElement $macro, DOMElement $macroReplacement ): array {
 		$params = [];
 		foreach ( $macro->childNodes as $childNode ) {
 			if ( $childNode->nodeName !== 'ac:parameter' ) {
@@ -66,11 +66,11 @@ class WidgetMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 * @param string $name
 	 * @return DOMNode|null
 	 */
-	private function getAttribute( DOMNode $node, string $name ): ?DOMNode {
+	private function getAttribute( DOMElement $node, string $name ): ?DOMNode {
 		$attributes = $node->attributes;
 
 		if ( $attributes && $attributes->count() > 0 ) {
@@ -89,17 +89,20 @@ class WidgetMacro extends StructuredMacroProcessorBase {
 	}
 
 	/**
-	 * @param DOMNode $node
+	 * @param DOMElement $node
 	 *
 	 * @return string|null
 	 */
-	private function getParamValue( DOMNode $node ): ?string {
+	private function getParamValue( DOMElement $node ): ?string {
 		$value = '';
 		$childNodes = $node->childNodes;
 
 		if ( $childNodes->count() > 0 ) {
 			for ( $index = 0; $index < $childNodes->count(); $index++ ) {
 				$child = $childNodes->item( $index );
+				if ( !( $child instanceof DOMElement ) ) {
+					continue;
+				}
 				$attrName = $this->getAttribute( $child, 'ri:value' );
 				if ( !$attrName ) {
 					continue;

--- a/src/Database/WorkspaceDB.php
+++ b/src/Database/WorkspaceDB.php
@@ -3749,7 +3749,10 @@ class WorkspaceDB {
 	 *
 	 * @param int $spaceId
 	 * @param string $rawPageTitle
-	 * @return string[] Map of confluenceFileKey => metadata (including 'targetTitle')
+	 *
+	 * @return array[] Map of confluenceFileKey => metadata (including 'targetTitle')
+	 *
+	 * @psalm-return array<array{targetTitle: mixed,...}>
 	 */
 	public function getAttachmentMetadataForPage( int $spaceId, string $rawPageTitle ): array {
 		$transaction = $this->cachedPrepare(
@@ -3795,7 +3798,10 @@ class WorkspaceDB {
 	 *
 	 * @param int $spaceId
 	 * @param string $rawBlogPostTitle
-	 * @return string[] Map of confluenceFileKey => metadata (including 'targetTitle')
+	 *
+	 * @return array[] Map of confluenceFileKey => metadata (including 'targetTitle')
+	 *
+	 * @psalm-return array<array{targetTitle: mixed,...}>
 	 */
 	public function getAttachmentMetadataForBlogPost( int $spaceId, string $rawBlogPostTitle ): array {
 		$transaction = $this->cachedPrepare(

--- a/src/Extractor/Preprocessor/UpdateBlogPostsTableWithSpaceIdOfHistoryVersions.php
+++ b/src/Extractor/Preprocessor/UpdateBlogPostsTableWithSpaceIdOfHistoryVersions.php
@@ -51,7 +51,7 @@ class UpdateBlogPostsTableWithSpaceIdOfHistoryVersions extends ProcessorBase {
 				continue;
 			}
 
-			$originalSpaceId = (int)$pageIdToSpaceIdMap[$originalVersionId];
+			$originalSpaceId = $pageIdToSpaceIdMap[$originalVersionId];
 
 			$this->workspaceDB->updateBlogPostSpaceId( $pageId, $originalSpaceId );
 			$this->writeln(

--- a/src/Extractor/Preprocessor/UpdatePagesTableWithSpaceIdOfHistoryVersions.php
+++ b/src/Extractor/Preprocessor/UpdatePagesTableWithSpaceIdOfHistoryVersions.php
@@ -51,7 +51,7 @@ class UpdatePagesTableWithSpaceIdOfHistoryVersions extends ProcessorBase {
 			if ( !isset( $pageIdToSpaceIdMap[$originalVersionId] ) ) {
 				continue;
 			}
-			$originalSpaceId = (int)$pageIdToSpaceIdMap[$originalVersionId];
+			$originalSpaceId = $pageIdToSpaceIdMap[$originalVersionId];
 
 			$this->workspaceDB->updatePageSpaceId( $pageId, $originalSpaceId );
 			$this->writeln(

--- a/src/Utility/DBConversionDataLookup.php
+++ b/src/Utility/DBConversionDataLookup.php
@@ -177,7 +177,7 @@ class DBConversionDataLookup {
 		if ( !$reference ) {
 			return null;
 		}
-		if ( $reference === null || !file_exists( $reference ) ) {
+		if ( !file_exists( $reference ) ) {
 			return null;
 		}
 		$content = file_get_contents( $reference );

--- a/src/Utility/DrawIOFileHandler.php
+++ b/src/Utility/DrawIOFileHandler.php
@@ -25,7 +25,7 @@ class DrawIOFileHandler {
 	 * @return bool
 	 */
 	public function isDrawIOImage( string $fileName ): bool {
-		return preg_match( '#\.drawio\.png$#', $fileName );
+		return (bool)preg_match( '#\.drawio\.png$#', $fileName );
 	}
 
 	/**
@@ -37,18 +37,18 @@ class DrawIOFileHandler {
 	 * In that case one of the ways to determine if that's DrawIO data file - is to look on its content.
 	 * DrawIO data file should look like that:
 	 * <code>
-	 *     <mxfile host="some.host" ...>
-	 *         <diagram id="..." ...>
-	 *          	...
-	 * 		   </diagram>
-	 *     </mxfile>
+	 * <mxfile host="some.host" ...>
+	 * <diagram id="..." ...>
+	 * ...
+	 * </diagram>
+	 * </mxfile>
 	 * </code>
 	 *
 	 * @param string $fileContent
 	 * @return bool
 	 */
 	public function isDrawIODataContent( string $fileContent ): bool {
-		return preg_match( '#<mxfile.*?>\s*.*\s*<diagram.*?>#', $fileContent );
+		return (bool)preg_match( '#<mxfile.*?>\s*.*\s*<diagram.*?>#', $fileContent );
 	}
 
 	/**


### PR DESCRIPTION
The commit was co-authored by Copilot. It was asked to use vimeo/psalm to find type problems and fix them.

This PR is *not* meant to be merged as-is. Instead it’s more like a “pick and choose” buffet of potential fixes.

There are important shortcomings that need to have kept an eye on. Especially the cases where a variable assignment was removed but the according array access was kept, because the tool couldn’t infer potential side effects.
