### PR TITLE
clean up code

### DIFF
--- a/src/Composer/Processor/FileProcessorBase.php
+++ b/src/Composer/Processor/FileProcessorBase.php
@@ -160,7 +160,7 @@ abstract class FileProcessorBase implements IConfluenceComposerProcessor {
 	 * @param string $pageTitle
 	 * @return string
 	 */
-	protected function gereralizeFilename( string $pageTitle ): string {
+	protected function generalizeFilename( string $pageTitle ): string {
 		return str_replace( ':', '_', $pageTitle );
 	}
 

--- a/src/Composer/Processor/Files.php
+++ b/src/Composer/Processor/Files.php
@@ -82,7 +82,7 @@ class Files extends FileProcessorBase {
 			return;
 		}
 
-		$filename = $this->gereralizeFilename( $attachmentPageTitle );
+		$filename = $this->generalizeFilename( $attachmentPageTitle );
 
 		// We do not need DrawIO data files in our wiki, just PNG image
 		if ( $this->isDrawioDataFile( $filename ) ) {
@@ -163,7 +163,7 @@ class Files extends FileProcessorBase {
 				continue;
 			}
 
-			$filename = $this->gereralizeFilename( $attachmentPageTitle );
+			$filename = $this->generalizeFilename( $attachmentPageTitle );
 
 			$attachments = $this->dataLookup->getAttachmentRevisionsForAttachmentId( $attachmentId );
 			foreach ( $attachments as $attachment ) {

--- a/src/Extractor/Preprocessor/AttachmentTableUpdaterBase.php
+++ b/src/Extractor/Preprocessor/AttachmentTableUpdaterBase.php
@@ -20,6 +20,9 @@ use SplFileInfo;
  */
 abstract class AttachmentTableUpdaterBase extends ProcessorBase {
 
+	private const MAX_UNCOLLIDE_ATTEMPTS = 10000;
+	private const UNKNOWN_EXTENSION = '.unknown';
+
 	/** @var MigrationConfig */
 	private MigrationConfig $migrationConfig;
 
@@ -154,15 +157,14 @@ abstract class AttachmentTableUpdaterBase extends ProcessorBase {
 			// Uncollide file title
 			$exists = $this->checkWikiTitleExists( $attachmentWikiTitle );
 			$counter = 1;
-			$maxUncollideAttempts = 10000;
 			while ( $exists ) {
-				if ( $counter > $maxUncollideAttempts ) {
+				if ( $counter > self::MAX_UNCOLLIDE_ATTEMPTS ) {
 					$this->dbLog->addLogEntry(
 						'warning',
 						'analyze',
 						__CLASS__,
 						"Could not find unique {$this->getContentLabel()} attachment title for attachment "
-						. "$attachmentId after " . (string)$maxUncollideAttempts . ' attempts'
+						. "$attachmentId after " . (string)self::MAX_UNCOLLIDE_ATTEMPTS . ' attempts'
 					);
 					continue 2;
 				}
@@ -180,7 +182,7 @@ abstract class AttachmentTableUpdaterBase extends ProcessorBase {
 
 			$file = new SplFileInfo( $attachmentWikiTitle );
 			if ( $file->getExtension() === '' || strlen( $file->getExtension() ) > 10 ) {
-				$attachmentWikiTitle .= '.unknown';
+				$attachmentWikiTitle .= self::UNKNOWN_EXTENSION;
 			}
 
 			$this->writeln(
@@ -206,7 +208,7 @@ abstract class AttachmentTableUpdaterBase extends ProcessorBase {
 				$this->workspaceDB->addInvalidAttachmentTitle(
 					$attachmentId,
 					$wikiTitle,
-					'Attachment title contains to many characters (>256)'
+					'Attachment title contains too many characters (>255)'
 				);
 			}
 		}

--- a/src/Extractor/Preprocessor/PopulateAdditionalAttachmentsTable.php
+++ b/src/Extractor/Preprocessor/PopulateAdditionalAttachmentsTable.php
@@ -17,6 +17,8 @@ use HalloWelt\MigrateConfluence\Utility\TitleValidityChecker;
  */
 class PopulateAdditionalAttachmentsTable extends ProcessorBase {
 
+	private const MAX_UNCOLLIDE_ATTEMPTS = 10000;
+
 	/** @var MigrationConfig */
 	private MigrationConfig $migrationConfig;
 
@@ -86,7 +88,7 @@ class PopulateAdditionalAttachmentsTable extends ProcessorBase {
 			);
 
 			try {
-				$attatchmentWikiTitle = $filenameBuilder->buildFromAttachmentData(
+				$attachmentWikiTitle = $filenameBuilder->buildFromAttachmentData(
 					$attachmentSpaceId,
 					$attachmentOrigFilename,
 					''
@@ -103,45 +105,44 @@ class PopulateAdditionalAttachmentsTable extends ProcessorBase {
 			}
 
 			// Uncollide file title
-			$exists = ( $this->workspaceDB->checkPageAttachmentWikiTitleExists( $attatchmentWikiTitle )
-				|| $this->workspaceDB->checkAdditionalAttachmentWikiTitleExists( $attatchmentWikiTitle )
+			$exists = ( $this->workspaceDB->checkPageAttachmentWikiTitleExists( $attachmentWikiTitle )
+				|| $this->workspaceDB->checkAdditionalAttachmentWikiTitleExists( $attachmentWikiTitle )
 			);
 
 			$counter = 1;
-			$maxUncollideAttempts = 10000;
 			while ( $exists ) {
-				if ( $counter > $maxUncollideAttempts ) {
+				if ( $counter > self::MAX_UNCOLLIDE_ATTEMPTS ) {
 					$this->dbLog->addLogEntry(
 						'warning',
 						'analyze',
 						__CLASS__,
 						"Could not find unique additional attachment title for attachment $attachmentId after "
-						. (string)$maxUncollideAttempts . ' attempts'
+						. (string)self::MAX_UNCOLLIDE_ATTEMPTS . ' attempts'
 					);
 					continue 2;
 				}
 
-				$attatchmentWikiTitle = $filenameBuilder->buildFromAttachmentData(
+				$attachmentWikiTitle = $filenameBuilder->buildFromAttachmentData(
 					$attachmentSpaceId,
 					$attachmentOrigFilename,
 					'',
 					"-(" . (string)$counter . ")"
 				);
 
-				$exists = ( $this->workspaceDB->checkPageAttachmentWikiTitleExists( $attatchmentWikiTitle )
-					|| $this->workspaceDB->checkAdditionalAttachmentWikiTitleExists( $attatchmentWikiTitle )
+				$exists = ( $this->workspaceDB->checkPageAttachmentWikiTitleExists( $attachmentWikiTitle )
+					|| $this->workspaceDB->checkAdditionalAttachmentWikiTitleExists( $attachmentWikiTitle )
 				);
 				$counter++;
 			}
 
 			$this->writeln(
-				"Add additional attachment for attachment ID $attachmentId with title: $attatchmentWikiTitle"
+				"Add additional attachment for attachment ID $attachmentId with title: $attachmentWikiTitle"
 			);
 
 			$this->workspaceDB->addAdditionalAttachment(
 				$attachmentId,
 				(string)$attachment['filename'],
-				$attatchmentWikiTitle
+				$attachmentWikiTitle
 			);
 		}
 	}
@@ -159,7 +160,7 @@ class PopulateAdditionalAttachmentsTable extends ProcessorBase {
 				$this->workspaceDB->addInvalidAttachmentTitle(
 					$attachmentId,
 					$wikiTitle,
-					'Attachment title contains to many characters (>256)'
+					'Attachment title contains too many characters (>255)'
 				);
 			}
 		}

--- a/src/Extractor/Preprocessor/UpdateBlogPostsTableWithSpaceIdOfHistoryVersions.php
+++ b/src/Extractor/Preprocessor/UpdateBlogPostsTableWithSpaceIdOfHistoryVersions.php
@@ -2,62 +2,20 @@
 
 namespace HalloWelt\MigrateConfluence\Extractor\Preprocessor;
 
-use HalloWelt\MigrateConfluence\Extractor\ProcessorBase;
+class UpdateBlogPostsTableWithSpaceIdOfHistoryVersions extends UpdateTableWithSpaceIdOfHistoryVersionsBase {
 
-/**
- * Space id of historical versions can be -1 but we need the space id for converter
- * Use space id from original version and update history versions
- */
-class UpdateBlogPostsTableWithSpaceIdOfHistoryVersions extends ProcessorBase {
-
-	/**
-	 * @return void
-	 */
-	public function execute(): void {
-		$pageIdToSpaceIdMap = [];
-		$blogPosts = $this->workspaceDB->getBlogPosts();
-
-		foreach ( $blogPosts as $blogPost ) {
-			if ( !isset( $blogPost['page_id'] ) || !array_key_exists( 'space_id', $blogPost ) ) {
-				continue;
-			}
-
-			if ( $blogPost['space_id'] === null ) {
-				continue;
-			}
-
-			$pageIdToSpaceIdMap[(int)$blogPost['page_id']] = (int)$blogPost['space_id'];
-		}
-
-		foreach ( $blogPosts as $blogPost ) {
-			if ( !isset( $blogPost['page_id'] )
-				|| !array_key_exists( 'space_id', $blogPost )
-				|| !isset( $blogPost['original_version_id'] )
-			) {
-				continue;
-			}
-
-			$originalVersionId = (int)$blogPost['original_version_id'];
-			if ( $originalVersionId === -1 ) {
-				continue;
-			}
-
-			if ( $blogPost['space_id'] !== null ) {
-				continue;
-			}
-			$pageId = (int)$blogPost['page_id'];
-
-			if ( !isset( $pageIdToSpaceIdMap[$originalVersionId] ) ) {
-				continue;
-			}
-
-			$originalSpaceId = (int)$pageIdToSpaceIdMap[$originalVersionId];
-
-			$this->workspaceDB->updateBlogPostSpaceId( $pageId, $originalSpaceId );
-			$this->writeln(
-				"Updated space_id for historical blog post ID $pageId with space_id: $originalSpaceId"
-			);
-		}
+	/** @inheritDoc */
+	protected function getRows(): array {
+		return $this->workspaceDB->getBlogPosts();
 	}
 
+	/** @inheritDoc */
+	protected function getContentLabel(): string {
+		return 'blog post';
+	}
+
+	/** @inheritDoc */
+	protected function updateSpaceId( int $pageId, int $spaceId ): void {
+		$this->workspaceDB->updateBlogPostSpaceId( $pageId, $spaceId );
+	}
 }

--- a/src/Extractor/Preprocessor/UpdateBlogPostsTableWithWikiTitle.php
+++ b/src/Extractor/Preprocessor/UpdateBlogPostsTableWithWikiTitle.php
@@ -70,12 +70,8 @@ class UpdateBlogPostsTableWithWikiTitle extends ProcessorBase {
 				"Creating wiki title for blog post ID $pageId with confluence title '$confluenceTitle'"
 			);
 
-			$namespace = '';
-			if ( isset( $spaceIdToPrefixMap[$spaceId] ) ) {
-				$prefix = $spaceIdToPrefixMap[$spaceId];
-				$namespace = substr( $prefix, 0, strpos( $prefix, ':' ) );
-				$namespace .= '/';
-			}
+			$prefix = $spaceIdToPrefixMap[$spaceId];
+			$namespace = substr( $prefix, 0, strpos( $prefix, ':' ) ) . '/';
 			$blogName = self::NS_BLOG_NAME;
 			$titleBuilder = new TitleBuilder( [ $spaceId => "$blogName:$namespace" ], [], [], [] );
 
@@ -131,14 +127,14 @@ class UpdateBlogPostsTableWithWikiTitle extends ProcessorBase {
 		foreach ( $titles as $pageId => $title ) {
 			if ( !$validityChecker->hasValidEnding( $title ) ) {
 				$this->workspaceDB->addInvalidBlogPostWikiTitle(
-					$pageId, $title, 'Title ens with invalid character'
+					$pageId, $title, 'Title ends with invalid character'
 				);
 			}
 
 			if ( str_contains( $title, ':' ) ) {
 				if ( $validityChecker->hasDoubleColon( $title ) ) {
 					$this->workspaceDB->addInvalidBlogPostWikiTitle(
-						$pageId, $title, 'Title contains multiple collons'
+						$pageId, $title, 'Title contains multiple colons'
 					);
 				}
 				$namespace = substr( $title, 0, strpos( $title, ':' ) );
@@ -152,13 +148,13 @@ class UpdateBlogPostsTableWithWikiTitle extends ProcessorBase {
 
 				if ( !$validityChecker->hasValidLength( $text ) ) {
 					$this->workspaceDB->addInvalidBlogPostWikiTitle(
-						$pageId, $title, 'Title contains to many characters (>256)'
+						$pageId, $title, 'Title contains too many characters (>255)'
 					);
 				}
 			} else {
 				if ( !$validityChecker->hasValidLength( $title ) ) {
 					$this->workspaceDB->addInvalidBlogPostWikiTitle(
-						$pageId, $title, 'Title contains to many characters (>256)'
+						$pageId, $title, 'Title contains too many characters (>255)'
 					);
 				}
 			}

--- a/src/Extractor/Preprocessor/UpdateBodyContentIdsFallback.php
+++ b/src/Extractor/Preprocessor/UpdateBodyContentIdsFallback.php
@@ -14,126 +14,69 @@ class UpdateBodyContentIdsFallback extends ProcessorBase {
 	 * @return void
 	 */
 	public function execute(): void {
-		// Update pages table
-		$this->updatePagesTable();
+		$this->updateBodyContentIdsForRows(
+			$this->workspaceDB->getPages(),
+			'page_id',
+			'page',
+			fn ( int $id, array $ids ) => $this->workspaceDB->updatePageBodyContentIds( $id, $ids )
+		);
 
-		// Update blog_posts table
-		$this->updateBlogPostsTable();
+		$this->updateBodyContentIdsForRows(
+			$this->workspaceDB->getBlogPosts(),
+			'page_id',
+			'blog post',
+			fn ( int $id, array $ids ) => $this->workspaceDB->updateBlogPostBodyContentIds( $id, $ids )
+		);
 
-		// Update comments table
-		$this->updateCommentsTable();
+		$this->updateBodyContentIdsForRows(
+			$this->workspaceDB->getComments(),
+			'comment_id',
+			'comment',
+			fn ( int $id, array $ids ) => $this->workspaceDB->updateCommentBodyContentIds( $id, $ids )
+		);
 
-		// Update spaces_descriptions table
-		$this->updateSpaceDescriptionsTable();
+		$this->updateBodyContentIdsForRows(
+			$this->workspaceDB->getSpaceDescriptions(),
+			'space_description_id',
+			'space description',
+			fn ( int $id, array $ids ) => $this->workspaceDB->updateSpaceDescriptionBodyContentIds( $id, $ids )
+		);
 	}
 
 	/**
+	 * For each row whose body_content_ids is empty, look up the IDs from the body_contents
+	 * table and persist them via the provided update callback.
+	 *
+	 * @param array $rows
+	 * @param string $idField Name of the primary-key field in each row.
+	 * @param string $contentLabel Human-readable label for log messages (e.g. "page").
+	 * @param callable $updateFn Callback: fn(int $id, array $ids): void
 	 * @return void
 	 */
-	private function updatePagesTable(): void {
-		$pages = $this->workspaceDB->getPages();
-		foreach ( $pages as $page ) {
-			if ( !isset( $page['page_id'] ) || !isset( $page['body_content_ids'] ) ) {
+	private function updateBodyContentIdsForRows(
+		array $rows, string $idField, string $contentLabel, callable $updateFn
+	): void {
+		foreach ( $rows as $row ) {
+			if ( !isset( $row[$idField] ) || !isset( $row['body_content_ids'] ) ) {
 				continue;
 			}
 
-			$pageId = (int)$page['page_id'];
-			$bodyContentIds = json_decode( $page['body_content_ids'], true );
+			$id = (int)$row[$idField];
+			$bodyContentIds = json_decode( $row['body_content_ids'], true );
 
-			// Check if body_content_ids is empty
-			if ( empty( $bodyContentIds ) || $bodyContentIds === null ) {
-				$foundIds = $this->workspaceDB->getBodyContentIdsForContentId( $pageId );
-				if ( !empty( $foundIds ) ) {
-					$this->writeln(
-						"Updated body_content_ids for page ID $pageId with IDs: "
-						. implode( ', ', $foundIds )
-					);
-					$this->workspaceDB->updatePageBodyContentIds( $pageId, $foundIds );
-				}
-
-			}
-		}
-		$this->writeln( "... done" );
-	}
-
-	/**
-	 * @return void
-	 */
-	private function updateBlogPostsTable(): void {
-		$blogPosts = $this->workspaceDB->getBlogPosts();
-		foreach ( $blogPosts as $blogPost ) {
-			if ( !isset( $blogPost['page_id'] ) || !isset( $blogPost['body_content_ids'] ) ) {
+			if ( !empty( $bodyContentIds ) ) {
 				continue;
 			}
 
-			$pageId = (int)$blogPost['page_id'];
-			$bodyContentIds = json_decode( $blogPost['body_content_ids'], true );
-
-			// Check if body_content_ids is empty
-			if ( empty( $bodyContentIds ) || $bodyContentIds === null ) {
-				$foundIds = $this->workspaceDB->getBodyContentIdsForContentId( $pageId );
-				if ( !empty( $foundIds ) ) {
-					$this->writeln(
-						"Updated body_content_ids for blog post ID $pageId with IDs: "
-						. implode( ', ', $foundIds )
-					);
-					$this->workspaceDB->updateBlogPostBodyContentIds( $pageId, $foundIds );
-				}
+			$foundIds = $this->workspaceDB->getBodyContentIdsForContentId( $id );
+			if ( !empty( $foundIds ) ) {
+				$this->writeln(
+					"Updated body_content_ids for $contentLabel ID $id with IDs: "
+					. implode( ', ', $foundIds )
+				);
+				$updateFn( $id, $foundIds );
 			}
 		}
-	}
-
-	/**
-	 * @return void
-	 */
-	private function updateCommentsTable(): void {
-		$comments = $this->workspaceDB->getComments();
-		foreach ( $comments as $comment ) {
-			if ( !isset( $comment['comment_id'] ) || !isset( $comment['body_content_ids'] ) ) {
-				continue;
-			}
-
-			$commentId = (int)$comment['comment_id'];
-			$bodyContentIds = json_decode( $comment['body_content_ids'], true );
-
-			// Check if body_content_ids is empty
-			if ( empty( $bodyContentIds ) || $bodyContentIds === null ) {
-				$foundIds = $this->workspaceDB->getBodyContentIdsForContentId( $commentId );
-				if ( !empty( $foundIds ) ) {
-					$this->writeln(
-						"Updated body_content_ids for comment ID $commentId with IDs: "
-						. implode( ', ', $foundIds )
-					);
-					$this->workspaceDB->updateCommentBodyContentIds( $commentId, $foundIds );
-				}
-			}
-		}
-	}
-
-	/**
-	 * @return void
-	 */
-	private function updateSpaceDescriptionsTable(): void {
-		$spaceDescriptions = $this->workspaceDB->getSpaceDescriptions();
-		foreach ( $spaceDescriptions as $spaceDesc ) {
-			if ( !isset( $spaceDesc['space_description_id'] ) || !isset( $spaceDesc['body_content_ids'] ) ) {
-				continue;
-			}
-
-			$spaceDescriptionId = (int)$spaceDesc['space_description_id'];
-			$bodyContentIds = json_decode( $spaceDesc['body_content_ids'], true );
-
-			// Check if body_content_ids is empty
-			if ( empty( $bodyContentIds ) || $bodyContentIds === null ) {
-				$foundIds = $this->workspaceDB->getBodyContentIdsForContentId( $spaceDescriptionId );
-				if ( !empty( $foundIds ) ) {
-					$this->writeln(
-						"Updated body_content_ids for space description ID $spaceDescriptionId with IDs: "
-						. implode( ', ', $foundIds )
-					);
-					$this->workspaceDB->updateSpaceDescriptionBodyContentIds( $spaceDescriptionId, $foundIds );
-				}
-			}
-		}
+		$this->writeln( '... done' );
 	}
 }

--- a/src/Extractor/Preprocessor/UpdatePagesTableWithSpaceIdOfHistoryVersions.php
+++ b/src/Extractor/Preprocessor/UpdatePagesTableWithSpaceIdOfHistoryVersions.php
@@ -2,62 +2,20 @@
 
 namespace HalloWelt\MigrateConfluence\Extractor\Preprocessor;
 
-use HalloWelt\MigrateConfluence\Extractor\ProcessorBase;
+class UpdatePagesTableWithSpaceIdOfHistoryVersions extends UpdateTableWithSpaceIdOfHistoryVersionsBase {
 
-/**
- * Space id of historical versions can be -1 but we need the space id for converter
- * Use space id from original version and update history versions
- */
-class UpdatePagesTableWithSpaceIdOfHistoryVersions extends ProcessorBase {
-
-	/**
-	 * @return void
-	 */
-	public function execute(): void {
-		$pageIdToSpaceIdMap = [];
-		$pages = $this->workspaceDB->getPages();
-
-		foreach ( $pages as $page ) {
-			if ( !isset( $page['page_id'] ) || !array_key_exists( 'space_id', $page ) ) {
-				continue;
-			}
-
-			if ( $page['space_id'] === null ) {
-				continue;
-			}
-
-			$pageIdToSpaceIdMap[(int)$page['page_id']] = (int)$page['space_id'];
-		}
-
-		foreach ( $pages as $page ) {
-			if ( !isset( $page['page_id'] )
-				|| !array_key_exists( 'space_id', $page )
-				|| !isset( $page['original_version_id'] )
-			) {
-				continue;
-			}
-
-			$originalVersionId = (int)$page['original_version_id'];
-			if ( $originalVersionId === -1 ) {
-				continue;
-			}
-
-			if ( $page['space_id'] !== null ) {
-				continue;
-			}
-
-			$pageId = (int)$page['page_id'];
-
-			if ( !isset( $pageIdToSpaceIdMap[$originalVersionId] ) ) {
-				continue;
-			}
-			$originalSpaceId = (int)$pageIdToSpaceIdMap[$originalVersionId];
-
-			$this->workspaceDB->updatePageSpaceId( $pageId, $originalSpaceId );
-			$this->writeln(
-				"Updated space_id for historical page ID $pageId with space_id: $originalSpaceId"
-			);
-		}
+	/** @inheritDoc */
+	protected function getRows(): array {
+		return $this->workspaceDB->getPages();
 	}
 
+	/** @inheritDoc */
+	protected function getContentLabel(): string {
+		return 'page';
+	}
+
+	/** @inheritDoc */
+	protected function updateSpaceId( int $pageId, int $spaceId ): void {
+		$this->workspaceDB->updatePageSpaceId( $pageId, $spaceId );
+	}
 }

--- a/src/Extractor/Preprocessor/UpdatePagesTableWithWikiTitle.php
+++ b/src/Extractor/Preprocessor/UpdatePagesTableWithWikiTitle.php
@@ -137,7 +137,7 @@ class UpdatePagesTableWithWikiTitle extends ProcessorBase {
 			if ( str_contains( $title, ':' ) ) {
 				if ( $validityChecker->hasDoubleColon( $title ) ) {
 					$this->workspaceDB->addInvalidPageWikiTitle(
-						$pageId, $title, 'Title contains multiple collons'
+						$pageId, $title, 'Title contains multiple colons'
 					);
 				}
 				$namespace = substr( $title, 0, strpos( $title, ':' ) );
@@ -151,13 +151,13 @@ class UpdatePagesTableWithWikiTitle extends ProcessorBase {
 
 				if ( !$validityChecker->hasValidLength( $text ) ) {
 					$this->workspaceDB->addInvalidPageWikiTitle(
-						$pageId, $title, 'Title contains to many characters (>256)'
+						$pageId, $title, 'Title contains too many characters (>255)'
 					);
 				}
 			} else {
 				if ( !$validityChecker->hasValidLength( $title ) ) {
 					$this->workspaceDB->addInvalidPageWikiTitle(
-						$pageId, $title, 'Title contains to many characters (>256)'
+						$pageId, $title, 'Title contains too many characters (>255)'
 					);
 				}
 			}

--- a/src/Extractor/Preprocessor/UpdateTableWithSpaceIdOfHistoryVersionsBase.php
+++ b/src/Extractor/Preprocessor/UpdateTableWithSpaceIdOfHistoryVersionsBase.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Extractor\Preprocessor;
+
+use HalloWelt\MigrateConfluence\Extractor\ProcessorBase;
+
+/**
+ * Base class for preprocessors that propagate a non-null space_id from
+ * the original version of a page/blog-post to all its historical versions.
+ *
+ * Space id of historical versions can be null but we need the space id for
+ * the converter. This class reads all rows, builds an id→space_id map from
+ * the rows that already have a space_id, then updates the rows whose
+ * space_id is still null.
+ */
+abstract class UpdateTableWithSpaceIdOfHistoryVersionsBase extends ProcessorBase {
+
+	/**
+	 * @return void
+	 */
+	public function execute(): void {
+		$pageIdToSpaceIdMap = [];
+		$rows = $this->getRows();
+
+		foreach ( $rows as $row ) {
+			if ( !isset( $row['page_id'] ) || !array_key_exists( 'space_id', $row ) ) {
+				continue;
+			}
+
+			if ( $row['space_id'] === null ) {
+				continue;
+			}
+
+			$pageIdToSpaceIdMap[(int)$row['page_id']] = (int)$row['space_id'];
+		}
+
+		foreach ( $rows as $row ) {
+			if (
+				!isset( $row['page_id'] )
+				|| !array_key_exists( 'space_id', $row )
+				|| !isset( $row['original_version_id'] )
+			) {
+				continue;
+			}
+
+			$originalVersionId = (int)$row['original_version_id'];
+			if ( $originalVersionId === -1 ) {
+				continue;
+			}
+
+			if ( $row['space_id'] !== null ) {
+				continue;
+			}
+
+			$pageId = (int)$row['page_id'];
+
+			if ( !isset( $pageIdToSpaceIdMap[$originalVersionId] ) ) {
+				continue;
+			}
+
+			$originalSpaceId = (int)$pageIdToSpaceIdMap[$originalVersionId];
+
+			$this->updateSpaceId( $pageId, $originalSpaceId );
+			$this->writeln(
+				"Updated space_id for historical {$this->getContentLabel()} ID $pageId"
+				. " with space_id: $originalSpaceId"
+			);
+		}
+	}
+
+	/**
+	 * Returns all rows for the content type (pages or blog posts).
+	 * Each row must contain at least 'page_id', 'space_id', and 'original_version_id'.
+	 *
+	 * @return array
+	 */
+	abstract protected function getRows(): array;
+
+	/**
+	 * Returns a human-readable label for the content type used in log messages.
+	 * E.g. "page" or "blog post".
+	 *
+	 * @return string
+	 */
+	abstract protected function getContentLabel(): string;
+
+	/**
+	 * Persists the resolved space_id for a single row.
+	 *
+	 * @param int $pageId
+	 * @param int $spaceId
+	 * @return void
+	 */
+	abstract protected function updateSpaceId( int $pageId, int $spaceId ): void;
+}

--- a/src/Utility/TitleBuilder.php
+++ b/src/Utility/TitleBuilder.php
@@ -26,7 +26,7 @@ class TitleBuilder {
 	/**
 	 * @var array
 	 */
-	private array $pageIConfluenceTitledMap;
+	private array $pageIdConfluenceTitleMap;
 
 	/**
 	 *
@@ -43,17 +43,17 @@ class TitleBuilder {
 	 * @param array $spaceIdPrefixMap
 	 * @param array $spaceIdHomepages
 	 * @param array $pageIdParentPageIdMap
-	 * @param array $pageIConfluenceTitledMap
+	 * @param array $pageIdConfluenceTitleMap
 	 * @param string $mainpage
 	 */
 	public function __construct(
 		array $spaceIdPrefixMap, array $spaceIdHomepages, array $pageIdParentPageIdMap,
-		array $pageIConfluenceTitledMap, string $mainpage = 'Main_Page'
+		array $pageIdConfluenceTitleMap, string $mainpage = 'Main_Page'
 	) {
 		$this->spaceIdPrefixMap = $spaceIdPrefixMap;
 		$this->spaceIdHomepages = $spaceIdHomepages;
 		$this->pageIdParentPageIdMap = $pageIdParentPageIdMap;
-		$this->pageIConfluenceTitledMap = $pageIConfluenceTitledMap;
+		$this->pageIdConfluenceTitleMap = $pageIdConfluenceTitleMap;
 		$this->mainpage = $mainpage;
 	}
 
@@ -110,8 +110,8 @@ class TitleBuilder {
 		while ( $parentPageId !== null ) {
 			if ( $parentPageId === $this->currentTitlesSpaceHomePageId ) {
 				break;
-			} elseif ( isset( $this->pageIConfluenceTitledMap[$parentPageId] ) ) {
-				$parentTitle = $this->pageIConfluenceTitledMap[$parentPageId];
+			} elseif ( isset( $this->pageIdConfluenceTitleMap[$parentPageId] ) ) {
+				$parentTitle = $this->pageIdConfluenceTitleMap[$parentPageId];
 			} else {
 				break;
 			}

--- a/src/Utility/TitleValidityChecker.php
+++ b/src/Utility/TitleValidityChecker.php
@@ -4,6 +4,8 @@ namespace HalloWelt\MigrateConfluence\Utility;
 
 class TitleValidityChecker {
 
+	private const MAX_TITLE_LENGTH = 255;
+
 	/**
 	 * @param string $title
 	 * @return bool
@@ -46,10 +48,7 @@ class TitleValidityChecker {
 	 * @return bool
 	 */
 	public function containsInvalidChar( string $title ): bool {
-		if ( str_contains( $title, '~' ) ) {
-			return true;
-		}
-		return false;
+		return str_contains( $title, '~' );
 	}
 
 	/**
@@ -57,10 +56,7 @@ class TitleValidityChecker {
 	 * @return bool
 	 */
 	public function hasValidEnding( string $title ): bool {
-		if ( str_ends_with( $title, '_' ) || str_ends_with( $title, '~' ) ) {
-			return false;
-		}
-		return true;
+		return !str_ends_with( $title, '_' ) && !str_ends_with( $title, '~' );
 	}
 
 	/**
@@ -68,10 +64,7 @@ class TitleValidityChecker {
 	 * @return bool
 	 */
 	public function hasDoubleColon( string $title ): bool {
-		if ( strpos( $title, ':' ) !== strrpos( $title, ':' ) ) {
-			return true;
-		}
-		return false;
+		return strpos( $title, ':' ) !== strrpos( $title, ':' );
 	}
 
 	/**
@@ -85,10 +78,7 @@ class TitleValidityChecker {
 
 		$matches = [];
 		preg_match( '#^(\d*)([a-zA-Z0-9_]*)$#', $namespace, $matches );
-		if ( empty( $matches ) || $matches[1] !== '' ) {
-			return false;
-		}
-		return true;
+		return !empty( $matches ) && $matches[1] === '';
 	}
 
 	/**
@@ -96,10 +86,7 @@ class TitleValidityChecker {
 	 * @return bool
 	 */
 	public function hasValidLength( string $title ): bool {
-		if ( strlen( $title ) > 255 ) {
-			return false;
-		}
-		return true;
+		return strlen( $title ) <= self::MAX_TITLE_LENGTH;
 	}
 
 }


### PR DESCRIPTION
This is a Copilot authored commit with clean-up suggestions
of recent changes. The prompt was:

> between git tag 3.0.0 and the current main branch there were lots of
> changes in `src/`. We suspect that there is a lot of potential to do
> clean-ups and refactorings, without changing the code behavior. create a
> list of potential code quality enhancements, ordered by their
> usefulness. check the content of `src/` and look for potentials in code
> deduplication, refactoring, enhancing of code quality, etc. based on the
> list. suggest code edits based on the ordered list.

The applied suggestions:

| # | Item | Files changed |
|---|------|--------------|
| 1 | **Extracted `UpdateTableWithSpaceIdOfHistoryVersionsBase`** — ~110 lines of duplicated `execute()` logic consolidated into one base class; both concrete classes reduced to ~20 lines each | `UpdateTableWithSpaceIdOfHistoryVersionsBase.php` *(new)*, `UpdatePages…SpaceId….php`, `UpdateBlogPosts…SpaceId….php` |
| 2 | **Consolidated `UpdateBodyContentIdsFallback`** — 4 near-identical private methods replaced by a single generic `updateBodyContentIdsForRows()` helper accepting a callable; also removed the redundant `\|\| $var === null` guard since `empty()` already covers `null` | `UpdateBodyContentIdsFallback.php` |
| 3 | **Simplified `TitleValidityChecker` boolean predicates** — all `if (cond) return X; return Y;` patterns replaced with direct `return cond;`; added `private const MAX_TITLE_LENGTH = 255` | `TitleValidityChecker.php` |
| 4 | **Fixed typos in identifiers** — `$attatchmentWikiTitle` → `$attachmentWikiTitle` (8×), `$pageIConfluenceTitledMap` → `$pageIdConfluenceTitleMap`, `gereralizeFilename` → `generalizeFilename` | `PopulateAdditionalAttachmentsTable.php`, `TitleBuilder.php`, `FileProcessorBase.php`, `Files.php` |
| 5 | **Fixed typos in error message strings** — `'collons'` → `'colons'`, `'ens with'` → `'ends with'`, `'to many'` → `'too many'`, corrected `(>256)` → `(>255)` to match the actual limit | `UpdateBlogPostsTableWithWikiTitle.php`, `UpdatePagesTableWithWikiTitle.php`, `AttachmentTableUpdaterBase.php`, `PopulateAdditionalAttachmentsTable.php` |
| 6 | **Extracted magic number constants** — `MAX_UNCOLLIDE_ATTEMPTS = 10000` and `UNKNOWN_EXTENSION = '.unknown'` | `AttachmentTableUpdaterBase.php`, `PopulateAdditionalAttachmentsTable.php` |
| 8 | **Removed redundant double `isset` check** — `isset($spaceIdToPrefixMap[$spaceId])` checked at line 65 then guarded again at line 74 in an unreachable `if`; collapsed to direct assignment | `UpdateBlogPostsTableWithWikiTitle.php` |
