### PR TITLE
restrict Docker build context to minimum needed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Docker builds: ignore everything in this folder except the files from the allow-list below
+*
+!docker
+!bin/migrate-confluence
+!src
+!composer.json
+!LICENSE
+!README.md
+!VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY ./docker/php/php.ini /usr/local/etc/php/php.ini
 
 RUN mkdir app
-COPY ./bin /app/bin
+COPY ./bin/migrate-confluence /app/bin/migrate-confluence
 COPY ./src /app/src
 COPY ./composer.json /app/composer.json
 COPY ./LICENSE /app/LICENSE


### PR DESCRIPTION
This is not completely right, though. If there are .bak or
.orig files or whatever in src/ those will still be used
for the build context as well. Therefore the suggestion is
still to build the container from a clean working tree.
