### PR TITLE
Fix processing without config option

### DIFF
--- a/src/Utility/ConfigOptionHelper.php
+++ b/src/Utility/ConfigOptionHelper.php
@@ -10,7 +10,7 @@ class ConfigOptionHelper {
 	/** @var array */
 	private array $advancedConfig = [];
 
-	public function __construct( private string $configFilePath = '' ) {
+	public function __construct( private ?string $configFilePath ) {
 	}
 
 	public function validateFile(): ?string {


### PR DESCRIPTION
If no config option is given, the config option helper throws an exception