### PR TITLE
add multimedia macro

### DIFF
--- a/src/Composer/_defaultpages/Template/Multimedia
+++ b/src/Composer/_defaultpages/Template/Multimedia
@@ -1,0 +1,8 @@
+<noinclude>Template for confluence macro "multimedia"
+</noinclude><includeonly>[[File:{{{filename}}}|{{#if: {{{width|}}}
+    |{{{width}}}
+|}}{{#if: {{{height|}}}
+    |x{{{height}}}
+|}}{{# if: {{{width|}}}{{{height|}}}
+    |px
+|}}]]</includeonly>

--- a/src/Converter/ConfluenceConverter.php
+++ b/src/Converter/ConfluenceConverter.php
@@ -60,6 +60,7 @@ use HalloWelt\MigrateConfluence\Converter\Processor\LocalTabGroupMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\LocalTabMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\LoremIpsumMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\MarkdownMacro;
+use HalloWelt\MigrateConfluence\Converter\Processor\MultimediaMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\NoFormatMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\NoteMacro;
 use HalloWelt\MigrateConfluence\Converter\Processor\PageLink;
@@ -482,6 +483,12 @@ class ConfluenceConverter extends PandocHTML implements IOutputAwareInterface, I
 				$this->migrationConfig
 			),
 			new ViewPdfMacro(
+				$this->dataLookup,
+				$this->currentSpace,
+				$this->confluencePageTitle,
+				$this->migrationConfig
+			),
+			new MultimediaMacro(
 				$this->dataLookup,
 				$this->currentSpace,
 				$this->confluencePageTitle,

--- a/src/Converter/Processor/MultimediaMacro.php
+++ b/src/Converter/Processor/MultimediaMacro.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Converter\Processor;
+
+/**
+ * <ac:structured-macro ac:name="multimedia">
+ *	 <ac:parameter ac:name="name">
+ *	   <ri:attachment ri:filename="Dummy.doc"/>
+ *	 </ac:parameter>
+ * </ac:structured-macro>
+ */
+class MultimediaMacro extends ViewFileMacro {
+
+	/**
+	 * @return string
+	 */
+	protected function getMacroName(): string {
+		return 'multimedia';
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getWikiTextTemplateName(): string {
+		return 'Multimedia';
+	}
+
+}

--- a/tests/phpunit/Converter/Processor/MultimediaMacroTest.php
+++ b/tests/phpunit/Converter/Processor/MultimediaMacroTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Converter\Processor;
+
+use HalloWelt\MigrateConfluence\Converter\Processor\MultimediaMacro;
+use HalloWelt\MigrateConfluence\Tests\Database\WorkspaceDbMock;
+use HalloWelt\MigrateConfluence\Utility\DBConversionDataLookup;
+use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
+use PHPUnit\Framework\TestCase;
+
+class MultimediaMacroTest extends TestCase {
+	/**
+	 * @var mixed
+	 */
+	private $dataLookup;
+
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Converter\Processor\MultimediaMacro::process
+	 * @return void
+	 */
+	public function testProcess() {
+		$this->dataLookup = new DBConversionDataLookup( ( new WorkspaceDbMock() )->createWithExtNsFileRepoCompat() );
+
+		/** SpaceId GENERAL */
+		$this->doTest(
+			0, "SomePage", 'multimedia-macro-input.xml', 'multimedia-macro-output-1.xml'
+		);
+
+		/** Random SpaceId */
+		$this->doTest(
+			23, "SomePage", 'multimedia-macro-input.xml', 'multimedia-macro-output-2.xml'
+		);
+	}
+
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Converter\Processor\MultimediaMacro::process
+	 * @return void
+	 */
+	public function testProcessBrokenMacro() {
+		$this->dataLookup = new DBConversionDataLookup( ( new WorkspaceDbMock() )->createWithoutExtNsFileRepoCompat() );
+
+		// Macros with no params at all, or with a name param but no ri:filename attribute,
+		// must be replaced with the broken-macro category marker.
+		$this->doTest(
+			0, "SomePage", 'multimedia-macro-broken-input.xml', 'multimedia-macro-broken-output.xml'
+		);
+	}
+
+	/**
+	 * @covers \HalloWelt\MigrateConfluence\Converter\Processor\MultimediaMacro::process
+	 * @return void
+	 */
+	public function testProcessUnmappedFilename() {
+		$this->dataLookup = new DBConversionDataLookup( ( new WorkspaceDbMock() )->createWithoutExtNsFileRepoCompat() );
+
+		// ri:filename is present but not found in the migration map: the macro must still
+		// render using the expected wiki filename (red link) and append Broken_attachment_link.
+		$this->doTest(
+			0, "SomePage", 'multimedia-macro-unmapped-input.xml', 'multimedia-macro-unmapped-output.xml'
+		);
+	}
+
+	/**
+	 * @param int $spaceId
+	 * @param string $pageName
+	 * @param string $input
+	 * @param string $output
+	 */
+	private function doTest( $spaceId, $pageName, $input, $output ) {
+		$dom = new \DOMDocument();
+		$dom->load( __DIR__ . '/../../data/' . $input );
+		$expectedOutput = file_get_contents( dirname( __DIR__, 2 ) . '/data/' . $output );
+		$processor = new MultimediaMacro( $this->dataLookup, $spaceId, $pageName, new MigrationConfig( [] ) );
+		$processor->process( $dom );
+		$actualOutput = $dom->saveXML();
+		$this->assertEquals( $expectedOutput, $actualOutput );
+	}
+}

--- a/tests/phpunit/data/FullMigration/SingleSource/expected/result_default-pages.xml
+++ b/tests/phpunit/data/FullMigration/SingleSource/expected/result_default-pages.xml
@@ -162,6 +162,21 @@
     </revision>
   </page>
   <page>
+    <title>Template:Multimedia</title>
+    <revision>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text>&lt;noinclude&gt;Template for confluence macro "multimedia"
+&lt;/noinclude&gt;&lt;includeonly&gt;[[File:{{{filename}}}|{{#if: {{{width|}}}
+    |{{{width}}}
+|}}{{#if: {{{height|}}}
+    |x{{{height}}}
+|}}{{# if: {{{width|}}}{{{height|}}}
+    |px
+|}}]]&lt;/includeonly&gt;</text>
+    </revision>
+  </page>
+  <page>
     <title>Template:Note</title>
     <revision>
       <model>wikitext</model>

--- a/tests/phpunit/data/multimedia-macro-broken-input.xml
+++ b/tests/phpunit/data/multimedia-macro-broken-input.xml
@@ -1,0 +1,9 @@
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-000000000001">
+	</ac:structured-macro>
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-000000000002">
+		<ac:parameter ac:name="name">
+			<ri:attachment ri:version-at-save="1" />
+		</ac:parameter>
+	</ac:structured-macro>
+</xml>

--- a/tests/phpunit/data/multimedia-macro-broken-output.xml
+++ b/tests/phpunit/data/multimedia-macro-broken-output.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	[[Category:Broken_macro/multimedia]]
+	[[Category:Broken_macro/multimedia]]
+</xml>

--- a/tests/phpunit/data/multimedia-macro-input.xml
+++ b/tests/phpunit/data/multimedia-macro-input.xml
@@ -1,0 +1,17 @@
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE">
+		<ac:parameter ac:name="name">
+			<ri:attachment ri:filename="Dummy_1.pdf" ri:version-at-save="1" />
+		</ac:parameter>
+	</ac:structured-macro>
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-FFFFFFFFFFFF">
+		<ac:parameter ac:name="name">
+			<ri:attachment ri:filename="Dummy_2.docx" ri:version-at-save="1" />
+		</ac:parameter>
+	</ac:structured-macro>
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-GGGGGGGGGGGG">
+		<ac:parameter ac:name="name">
+			<ri:attachment ri:filename="Dummy_3.png" ri:version-at-save="1" />
+		</ac:parameter>
+	</ac:structured-macro>
+</xml>

--- a/tests/phpunit/data/multimedia-macro-output-1.xml
+++ b/tests/phpunit/data/multimedia-macro-output-1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	{{Multimedia|filename = SomePage-Dummy_1.pdf|version-at-save = 1}}
+	{{Multimedia|filename = SomePage-Dummy_2.docx|version-at-save = 1}}
+	{{Multimedia|filename = SomePage-Dummy_3.png|version-at-save = 1}}
+</xml>

--- a/tests/phpunit/data/multimedia-macro-output-2.xml
+++ b/tests/phpunit/data/multimedia-macro-output-2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	{{Multimedia|filename = DEVOPS:SomePage-Dummy_1.pdf|version-at-save = 1}}
+	{{Multimedia|filename = DEVOPS:SomePage-Dummy_2.docx|version-at-save = 1}}
+	{{Multimedia|filename = DEVOPS:SomePage-Dummy_3.png|version-at-save = 1}}
+</xml>

--- a/tests/phpunit/data/multimedia-macro-unmapped-input.xml
+++ b/tests/phpunit/data/multimedia-macro-unmapped-input.xml
@@ -1,0 +1,7 @@
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	<ac:structured-macro ac:name="multimedia" ac:schema-version="1" ac:macro-id="AAAAAAAA-BBBB-CCCC-DDDD-000000000003">
+		<ac:parameter ac:name="name">
+			<ri:attachment ri:filename="NotInMap.mp4" ri:version-at-save="1" />
+		</ac:parameter>
+	</ac:structured-macro>
+</xml>

--- a/tests/phpunit/data/multimedia-macro-unmapped-output.xml
+++ b/tests/phpunit/data/multimedia-macro-unmapped-output.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<xml xmlns:ac="sample_namespace" xmlns:ri="sample_second_namespace">
+	{{Multimedia|filename = SomePage-NotInMap.mp4|version-at-save = 1}}[[Category:Broken_attachment_link]]
+</xml>


### PR DESCRIPTION
Parameters migrated without function:

- page: we do not support cross-wiki multimedia yet, apart from that
  this is a no-op in MediaWiki
- autostart: MediaWiki does not autostart media files. If it would, we’d
  need to make sure WCAG SCs 1.4.2, 2.2.2 and potentially others are not
  violated, so this is for now a good thing.

ERM48939
