### PR TITLE
fix issues with enhanced-sidebar.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The script imports files in this order:
 3. `comments.xml`
 4. `templates.xml`
 5. `pages.xml`
-6. if it exists, `enhanced-sidebar.xml`, containing the `MediaWiki:Sidebar.json` page for a sidebar that matches the Confluence one
+6. if it exists, `enhanced-sidebar.xml`, containing the `MediaWiki:Sidebar.json` page for a sidebar that reflects the Confluence space navigation (one file per namespace result folder)
 
 `user.xml` is intentionally ignored.
 

--- a/src/Composer/ConfluenceComposer.php
+++ b/src/Composer/ConfluenceComposer.php
@@ -87,6 +87,7 @@ class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, 
 
 		// Fetching namespaces
 		$namespaceMap = [];
+		$namespaceSpacesMap = [];
 		$spaces = $this->dataLookup->getSpaces();
 		foreach ( $spaces as $space ) {
 			$spaceId = (int)$space['space_id'];
@@ -97,8 +98,10 @@ class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, 
 
 			if ( !isset( $namespaceMap[$namespace] ) ) {
 				$namespaceMap[$namespace] = [];
+				$namespaceSpacesMap[$namespace] = [];
 			}
 			$namespaceMap[$namespace][] = $spaceId;
+			$namespaceSpacesMap[$namespace][] = $space;
 		}
 
 		// Run processors for each namespace
@@ -129,11 +132,12 @@ class ConfluenceComposer extends ComposerBase implements IOutputAwareInterface, 
 			$this->writeInvalidPageTemplatesLog( $spaceIds, $namespace );
 
 			$this->addImportHelper( $namespace );
+
+			( new Sidebar( $this->dataLookup, $this->migrationConfig, $this->dest ) )
+				->execute( $namespace, $namespaceSpacesMap[$namespace] );
 		}
 
 		$this->writeUserReadableDBLog( $dbLog );
-
-		( new Sidebar( $this->dataLookup, $this->migrationConfig, $this->dest ) )->execute();
 	}
 
 	/**

--- a/src/Composer/Processor/Sidebar.php
+++ b/src/Composer/Processor/Sidebar.php
@@ -22,7 +22,7 @@ class Sidebar {
 
 	/**
 	 * @param string $namespace The result sub-directory (e.g. "NS_MAIN", "MY_NS").
-	 * @param array  $spaces    Spaces belonging to this namespace, each with 'space_id' and 'space_name'.
+	 * @param array $spaces Spaces belonging to this namespace, each with 'space_id' and 'space_name'.
 	 * @return void
 	 */
 	public function execute( string $namespace, array $spaces ): void {

--- a/src/Composer/Processor/Sidebar.php
+++ b/src/Composer/Processor/Sidebar.php
@@ -21,17 +21,26 @@ class Sidebar {
 	}
 
 	/**
+	 * @param string $namespace The result sub-directory (e.g. "NS_MAIN", "MY_NS").
+	 * @param array  $spaces    Spaces belonging to this namespace, each with 'space_id' and 'space_name'.
 	 * @return void
 	 */
-	public function execute(): void {
+	public function execute( string $namespace, array $spaces ): void {
 		if ( !$this->migrationConfig->getCreateSidebar() ) {
 			return;
 		}
 
-		$spaces = $this->dataLookup->getSpaces();
-		$sidebar = count( $spaces ) > 1
-			? $this->buildMultiSpaceSidebar( $spaces )
-			: $this->buildSingleSpaceSidebar( $spaces );
+		$sidebar = [];
+		foreach ( $spaces as $space ) {
+			$section = $this->buildSpaceSection( $space );
+			if ( $section !== null ) {
+				$sidebar[] = $section;
+			}
+		}
+
+		if ( $sidebar === [] ) {
+			return;
+		}
 
 		$json = json_encode( $sidebar, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
@@ -45,7 +54,7 @@ class Sidebar {
 			'application/json'
 		);
 
-		$resultPath = $this->dest . '/result/';
+		$resultPath = $this->dest . '/result/' . $namespace . '/';
 		if ( !is_dir( $resultPath ) ) {
 			mkdir( $resultPath, 0755, true );
 		}
@@ -53,58 +62,39 @@ class Sidebar {
 	}
 
 	/**
-	 * Single space: top-level "Pages" and "Blogs" sections (omitting empty ones).
+	 * Builds a top-level section for a single space.
 	 *
-	 * @param array $spaces
-	 * @return array
-	 */
-	private function buildSingleSpaceSidebar( array $spaces ): array {
-		$spaceId = !empty( $spaces ) ? (int)$spaces[0]['space_id'] : null;
-		return $this->buildPagesBlogsSections( $spaceId );
-	}
-
-	/**
-	 * Multiple spaces: top-level per-space headings, each containing "Pages"/"Blogs" sections.
+	 * Structure:
+	 * - Space heading (always)
+	 *   - If both pages and blogs exist: "Pages" and "Blogs" sub-headings
+	 *   - If only one type: entries directly under the space heading (no sub-heading)
 	 *
-	 * @param array $spaces
-	 * @return array
-	 */
-	private function buildMultiSpaceSidebar( array $spaces ): array {
-		$sidebar = [];
-		foreach ( $spaces as $space ) {
-			$spaceId = (int)$space['space_id'];
-			$spaceName = (string)$space['space_name'];
-
-			$sections = $this->buildPagesBlogsSections( $spaceId );
-			if ( $sections === [] ) {
-				continue;
-			}
-
-			$sidebar[] = $this->buildSection( $spaceName, $sections );
-		}
-		return $sidebar;
-	}
-
-	/**
-	 * Builds "Pages" and/or "Blogs" sections for a space, skipping empty ones.
+	 * Returns null when the space has no content.
 	 *
-	 * @param int|null $spaceId
-	 * @return array
+	 * @param array $space
+	 * @return array|null
 	 */
-	private function buildPagesBlogsSections( ?int $spaceId ): array {
-		$sections = [];
+	private function buildSpaceSection( array $space ): ?array {
+		$spaceId = (int)$space['space_id'];
+		$spaceName = (string)$space['space_name'];
 
 		$pageEntries = $this->buildPageTree( $this->dataLookup->getPagesForSidebar( $spaceId ) );
-		if ( $pageEntries !== [] ) {
-			$sections[] = $this->buildSection( 'Pages', $pageEntries );
-		}
-
 		$blogEntries = $this->buildBlogList( $this->dataLookup->getBlogPostsForSidebar( $spaceId ) );
-		if ( $blogEntries !== [] ) {
-			$sections[] = $this->buildSection( 'Blogs', $blogEntries );
+
+		if ( $pageEntries === [] && $blogEntries === [] ) {
+			return null;
 		}
 
-		return $sections;
+		if ( $pageEntries !== [] && $blogEntries !== [] ) {
+			$children = [
+				$this->buildSection( 'Pages', $pageEntries ),
+				$this->buildSection( 'Blogs', $blogEntries ),
+			];
+		} else {
+			$children = $pageEntries !== [] ? $pageEntries : $blogEntries;
+		}
+
+		return $this->buildSection( $spaceName, $children );
 	}
 
 	/**

--- a/src/Composer/_shell/import.sh
+++ b/src/Composer/_shell/import.sh
@@ -11,7 +11,7 @@ Supports both single-file output (e.g. pages.xml) and split output
 (e.g. pages-00000001.xml, pages-00000002.xml, ...).
 
 Options:
-  --add-default    Also import default-files*.xml and default-pages*.xml
+  --add-default    Also import default-files*.xml, default-pages*.xml and enhanced-sidebar.xml
   --sfr=WIKI       Import into the WIKI wiki
 
 Import order:
@@ -20,7 +20,7 @@ Import order:
   3) comments*.xml (or page-talk*.xml + blog-talk*.xml if comments*.xml is absent)
   4) templates*.xml
   5) pages*.xml
-  6) ../sidebar.xml (if present)
+  6) enhanced-sidebar.xml (if present and --add-default is set)
 
 When --add-default is set, these are included:
   - default-files*.xml (before files*.xml)
@@ -187,8 +187,8 @@ if [[ "$add_default" -eq 1 ]]; then
 fi
 run_group "pages" "dump" "required"
 
-sidebar_file="$(dirname "$src")/sidebar.xml"
-if [[ -f "$sidebar_file" ]]; then
+sidebar_file="$src/enhanced-sidebar.xml"
+if [[ "$add_default" -eq 1 ]] && [[ -f "$sidebar_file" ]]; then
   echo "==> Importing sidebar from $sidebar_file"
   if ! run_import_dump_file "$sidebar_file"; then
     echo "Error: import failed for $sidebar_file" >&2

--- a/tests/phpunit/Composer/Processor/SidebarTest.php
+++ b/tests/phpunit/Composer/Processor/SidebarTest.php
@@ -14,6 +14,8 @@ class SidebarTest extends TestCase {
 
 	private string $tmpDir = '';
 
+	private string $testNamespace = 'NS_MAIN';
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->tmpDir = sys_get_temp_dir() . '/sidebar-test-' . uniqid( '', true );
@@ -38,7 +40,7 @@ class SidebarTest extends TestCase {
 	 * Parse enhanced-sidebar.xml and return the decoded JSON structure
 	 */
 	private function readSidebarJson(): array {
-		$path = $this->tmpDir . '/result/enhanced-sidebar.xml';
+		$path = $this->tmpDir . '/result/' . $this->testNamespace . '/enhanced-sidebar.xml';
 		$this->assertFileExists( $path );
 		$xml = simplexml_load_file( $path );
 		$this->assertNotFalse( $xml );
@@ -46,6 +48,10 @@ class SidebarTest extends TestCase {
 		$data = json_decode( $json, true );
 		$this->assertIsArray( $data );
 		return $data;
+	}
+
+	private function executeSidebar( Sidebar $sidebar, array $spaces ): void {
+		$sidebar->execute( $this->testNamespace, $spaces );
 	}
 
 	private function makeSpace( int $id, string $name ): array {
@@ -78,11 +84,13 @@ class SidebarTest extends TestCase {
 	 */
 	public function testCreateSidebarFalseWritesNoFile(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->expects( $this->never() )->method( 'getSpaces' );
+		$dataLookup->expects( $this->never() )->method( 'getPagesForSidebar' );
 
-		$this->makeSidebar( $dataLookup, false )->execute();
+		$this->makeSidebar( $dataLookup, false )->execute( $this->testNamespace, [] );
 
-		$this->assertFileDoesNotExist( $this->tmpDir . '/result/enhanced-sidebar.xml' );
+		$this->assertFileDoesNotExist(
+			$this->tmpDir . '/result/' . $this->testNamespace . '/enhanced-sidebar.xml'
+		);
 	}
 
 	/**
@@ -90,7 +98,6 @@ class SidebarTest extends TestCase {
 	 */
 	public function testSingleSpacePagesAndBlogs(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->with( 1 )->willReturn( [
 			$this->makePage( 10, 'PageA', -1, 100 ),
 			$this->makePage( 20, 'PageB', -1, 200 ),
@@ -99,53 +106,59 @@ class SidebarTest extends TestCase {
 			$this->makeBlog( 30, 'Blog:Post1' ),
 		] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
-		// Top level: Pages, Blogs (no space wrapper)
-		$this->assertCount( 2, $sidebar );
-		$this->assertSame( 'enhanced-sidebar-panel-heading', $sidebar[0]['type'] );
-		$this->assertSame( 'Pages', $sidebar[0]['text'] );
-		$this->assertCount( 2, $sidebar[0]['children'] );
-		$this->assertSame( 'Blogs', $sidebar[1]['text'] );
-		$this->assertCount( 1, $sidebar[1]['children'] );
+		// Top level: space name heading
+		$this->assertCount( 1, $sidebar );
+		$spaceSection = $sidebar[0];
+		$this->assertSame( 'enhanced-sidebar-panel-heading', $spaceSection['type'] );
+		$this->assertSame( 'Space A', $spaceSection['text'] );
+
+		// 2nd level: Pages and Blogs (both present)
+		$this->assertCount( 2, $spaceSection['children'] );
+		$this->assertSame( 'Pages', $spaceSection['children'][0]['text'] );
+		$this->assertCount( 2, $spaceSection['children'][0]['children'] );
+		$this->assertSame( 'Blogs', $spaceSection['children'][1]['text'] );
+		$this->assertCount( 1, $spaceSection['children'][1]['children'] );
 	}
 
 	public function testSingleSpaceNoBlogPosts(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'PageA' ),
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
-		// Only Pages section — no Blogs section
+		// Space heading, no Pages/Blogs sub-heading — entries directly as children
 		$this->assertCount( 1, $sidebar );
-		$this->assertSame( 'Pages', $sidebar[0]['text'] );
+		$this->assertSame( 'Space A', $sidebar[0]['text'] );
+		$this->assertCount( 1, $sidebar[0]['children'] );
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[0]['children'][0]['type'] );
 	}
 
 	public function testSingleSpaceNoPagesOnlyBlogs(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [
 			$this->makeBlog( 30, 'Blog:Post1' ),
 		] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
-		// Only Blogs section
+		// Space heading, blog entry directly as child (no Blogs sub-heading)
 		$this->assertCount( 1, $sidebar );
-		$this->assertSame( 'Blogs', $sidebar[0]['text'] );
+		$this->assertSame( 'Space A', $sidebar[0]['text'] );
+		$this->assertCount( 1, $sidebar[0]['children'] );
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[0]['children'][0]['type'] );
 	}
 
 	public function testSingleSpacePagesSortedByPosition(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'Second', -1, 200 ),
 			$this->makePage( 20, 'First', -1, 100 ),
@@ -153,9 +166,10 @@ class SidebarTest extends TestCase {
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
+		// Only pages → direct children of space section
 		$children = $sidebar[0]['children'];
 		$this->assertSame( 'First', $children[0]['page'] );
 		$this->assertSame( 'Second', $children[1]['page'] );
@@ -164,7 +178,6 @@ class SidebarTest extends TestCase {
 
 	public function testSingleSpaceNestedPages(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'Parent', -1, 100 ),
 			$this->makePage( 20, 'Child', 10, 100 ),
@@ -172,9 +185,10 @@ class SidebarTest extends TestCase {
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
+		// Only pages → direct children of space section
 		$root = $sidebar[0]['children'];
 		$this->assertCount( 1, $root );
 		$this->assertSame( 'Parent', $root[0]['page'] );
@@ -193,13 +207,12 @@ class SidebarTest extends TestCase {
 
 	public function testSingleSpaceLeafPageHasNoChildrenKey(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'Leaf', -1, 0 ),
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
 		$this->assertArrayNotHasKey( 'children', $sidebar[0]['children'][0] );
@@ -207,13 +220,12 @@ class SidebarTest extends TestCase {
 
 	public function testDisplayTextUsesConfluenceTitle(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'MyNamespace:My_Page~1', -1, 0, 'My Page with a Very Long Original Title' ),
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
 		$link = $sidebar[0]['children'][0];
@@ -223,13 +235,12 @@ class SidebarTest extends TestCase {
 
 	public function testDisplayTextUsesConfluenceTitleForBlogs(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [
 			$this->makeBlog( 30, 'NS:Blog_post~1', 'My Blog Post Title' ),
 		] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
 		$link = $sidebar[0]['children'][0];
@@ -239,13 +250,12 @@ class SidebarTest extends TestCase {
 
 	public function testDisplayTextMatchesWikiTitleWhenNotMangled(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [ $this->makeSpace( 1, 'Space A' ) ] );
 		$dataLookup->method( 'getPagesForSidebar' )->willReturn( [
 			$this->makePage( 10, 'Spalten', -1, 0, 'Spalten' ),
 		] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [ $this->makeSpace( 1, 'Space A' ) ] );
 		$sidebar = $this->readSidebarJson();
 
 		$link = $sidebar[0]['children'][0];
@@ -254,14 +264,10 @@ class SidebarTest extends TestCase {
 	}
 
 	/**
-	 * Multi-space
+	 * Multi-space (within same namespace)
 	 */
 	public function testMultiSpaceCreatesSpaceHeadings(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [
-			$this->makeSpace( 1, 'Space A' ),
-			$this->makeSpace( 2, 'Space B' ),
-		] );
 		$dataLookup->method( 'getPagesForSidebar' )
 			->willReturnMap( [
 				[ 1, [ $this->makePage( 10, 'NS_A:PageA' ) ] ],
@@ -273,24 +279,23 @@ class SidebarTest extends TestCase {
 				[ 2, [] ],
 			] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [
+			$this->makeSpace( 1, 'Space A' ),
+			$this->makeSpace( 2, 'Space B' ),
+		] );
 		$sidebar = $this->readSidebarJson();
 
 		$this->assertCount( 2, $sidebar );
 		$this->assertSame( 'Space A', $sidebar[0]['text'] );
 		$this->assertSame( 'Space B', $sidebar[1]['text'] );
 
-		// Each space wraps a Pages section
-		$this->assertSame( 'Pages', $sidebar[0]['children'][0]['text'] );
-		$this->assertSame( 'Pages', $sidebar[1]['children'][0]['text'] );
+		// Only pages → direct children (no Pages sub-heading)
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[0]['children'][0]['type'] );
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[1]['children'][0]['type'] );
 	}
 
 	public function testMultiSpaceWithBlogsInOneSpace(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [
-			$this->makeSpace( 1, 'Space A' ),
-			$this->makeSpace( 2, 'Space B' ),
-		] );
 		$dataLookup->method( 'getPagesForSidebar' )
 			->willReturnMap( [
 				[ 1, [ $this->makePage( 10, 'PageA' ) ] ],
@@ -302,23 +307,42 @@ class SidebarTest extends TestCase {
 				[ 2, [ $this->makeBlog( 30, 'Blog:Post1' ) ] ],
 			] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [
+			$this->makeSpace( 1, 'Space A' ),
+			$this->makeSpace( 2, 'Space B' ),
+		] );
 		$sidebar = $this->readSidebarJson();
 
-		// Space A: only Pages; Space B: only Blogs
+		// Space A: only pages → direct children; Space B: only blogs → direct children
 		$this->assertCount( 2, $sidebar );
-		$this->assertCount( 1, $sidebar[0]['children'] );
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[0]['children'][0]['type'] );
+		$this->assertSame( 'enhanced-sidebar-internal-link', $sidebar[1]['children'][0]['type'] );
+	}
+
+	public function testMultiSpaceBothPagesAndBlogsGetSubHeadings(): void {
+		$dataLookup = $this->createMock( DBComposerDataLookup::class );
+		$dataLookup->method( 'getPagesForSidebar' )
+			->willReturnMap( [
+				[ 1, [ $this->makePage( 10, 'PageA' ) ] ],
+			] );
+		$dataLookup->method( 'getBlogPostsForSidebar' )
+			->willReturnMap( [
+				[ 1, [ $this->makeBlog( 30, 'Blog:Post1' ) ] ],
+			] );
+
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [
+			$this->makeSpace( 1, 'Space A' ),
+		] );
+		$sidebar = $this->readSidebarJson();
+
+		// Both → Pages and Blogs sub-headings
+		$this->assertSame( 'Space A', $sidebar[0]['text'] );
 		$this->assertSame( 'Pages', $sidebar[0]['children'][0]['text'] );
-		$this->assertCount( 1, $sidebar[1]['children'] );
-		$this->assertSame( 'Blogs', $sidebar[1]['children'][0]['text'] );
+		$this->assertSame( 'Blogs', $sidebar[0]['children'][1]['text'] );
 	}
 
 	public function testMultiSpaceEmptySpaceIsSkipped(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [
-			$this->makeSpace( 1, 'Space A' ),
-			$this->makeSpace( 2, 'Empty Space' ),
-		] );
 		$dataLookup->method( 'getPagesForSidebar' )
 			->willReturnMap( [
 				[ 1, [ $this->makePage( 10, 'PageA' ) ] ],
@@ -330,20 +354,18 @@ class SidebarTest extends TestCase {
 				[ 2, [] ],
 			] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [
+			$this->makeSpace( 1, 'Space A' ),
+			$this->makeSpace( 2, 'Empty Space' ),
+		] );
 		$sidebar = $this->readSidebarJson();
 
-		// Empty Space should be omitted entirely
 		$this->assertCount( 1, $sidebar );
 		$this->assertSame( 'Space A', $sidebar[0]['text'] );
 	}
 
 	public function testMultiSpacePagesSortedByPosition(): void {
 		$dataLookup = $this->createMock( DBComposerDataLookup::class );
-		$dataLookup->method( 'getSpaces' )->willReturn( [
-			$this->makeSpace( 1, 'Space A' ),
-			$this->makeSpace( 2, 'Space B' ),
-		] );
 		$dataLookup->method( 'getPagesForSidebar' )
 			->willReturnMap( [
 				[ 1, [
@@ -354,10 +376,14 @@ class SidebarTest extends TestCase {
 			] );
 		$dataLookup->method( 'getBlogPostsForSidebar' )->willReturn( [] );
 
-		$this->makeSidebar( $dataLookup )->execute();
+		$this->executeSidebar( $this->makeSidebar( $dataLookup ), [
+			$this->makeSpace( 1, 'Space A' ),
+			$this->makeSpace( 2, 'Space B' ),
+		] );
 		$sidebar = $this->readSidebarJson();
 
-		$pages = $sidebar[0]['children'][0]['children'];
+		// Only pages → direct children of space section
+		$pages = $sidebar[0]['children'];
 		$this->assertSame( 'First', $pages[0]['page'] );
 		$this->assertSame( 'Second', $pages[1]['page'] );
 	}


### PR DESCRIPTION
* ignored namespaces were still in the sidebar
* the structure is enhanced: do not use the space as inner heading but as top-level heading (removing one level)
* fixed the import.sh script re: filename and import only with `--add-default` to prevent double imports
* add `enhanced-sidebar.xml` in each result/* folder, so that those are all self-contained.

ERM49075
