### PR TITLE
extract info from exportDescriptor.properties files

### DIFF
--- a/src/Analyzer/ConfluenceAnalyzer.php
+++ b/src/Analyzer/ConfluenceAnalyzer.php
@@ -72,10 +72,43 @@ class ConfluenceAnalyzer implements LoggerAwareInterface, IAnalyzer {
 		$processors = $this->getProcessors( $file->getPath() );
 
 		$this->workspaceDB->beginTransaction();
+		$this->processExportDescriptor( $file );
 		$this->processFile( $sourcePath, $processors );
 		$this->workspaceDB->commitTransaction();
 
 		return true;
+	}
+
+	/**
+	 * @param SplFileInfo $entitiesFile
+	 * @return void
+	 */
+	private function processExportDescriptor( SplFileInfo $entitiesFile ): void {
+		$descriptorPath = $entitiesFile->getPath() . '/exportDescriptor.properties';
+		if ( !file_exists( $descriptorPath ) ) {
+			return;
+		}
+
+		$props = [];
+		foreach ( file( $descriptorPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES ) as $line ) {
+			if ( str_starts_with( $line, '#' ) ) {
+				if ( empty( $props['_date'] ) ) {
+					$props['_date'] = ltrim( $line, '#' );
+				}
+				continue;
+			}
+			[ $key, $value ] = explode( '=', $line, 2 ) + [ 1 => '' ];
+			$props[trim( $key )] = trim( $value );
+		}
+
+		$this->workspaceDB->addExportProperties(
+			$props['spaceKey'] ?? '',
+			$props['source'] ?? '',
+			$props['createdByVersionNumber'] ?? '',
+			trim( $props['_date'] ?? '' ),
+			$props['timezoneId'] ?? '',
+			basename( $entitiesFile->getPath() ) . '/' . $entitiesFile->getFilename()
+		);
 	}
 
 	/**

--- a/src/Database/WorkspaceDB.php
+++ b/src/Database/WorkspaceDB.php
@@ -284,6 +284,7 @@ class WorkspaceDB {
 		$this->createTablePageTemplates();
 		$this->createTablePageTemplateContents();
 		$this->createTableAttachmentsDescriptions();
+		$this->createTableExportProperties();
 
 		// Indexing tables
 		$this->createIndexes();
@@ -772,6 +773,52 @@ class WorkspaceDB {
 		$row = $result->fetchArray( SQLITE3_ASSOC );
 		$result->finalize();
 		return $row !== false ? (string)$row['description'] : '';
+	}
+
+	/**
+	 * @return void
+	 */
+	private function createTableExportProperties(): void {
+		$this->db->exec(
+			'CREATE TABLE IF NOT EXISTS export_properties (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				space_key CHAR,
+				source CHAR,
+				confluence_version CHAR,
+				export_date CHAR,
+				timezone_id CHAR,
+				entities_xml_path CHAR
+			);'
+		);
+	}
+
+	/**
+	 * @param string $spaceKey The Confluence space key (e.g. "HR"), from exportDescriptor.properties `spaceKey`
+	 * @param string $source Export origin: "server" or "cloud"
+	 * @param string $confluenceVersion Confluence version that created the export, e.g. "7.19.18"
+	 * @param string $exportDate Raw timestamp from the properties comment line, e.g. "Mon May 18 11:58:00 CEST 2026"
+	 * @param string $timezoneId Timezone of the exporting instance, e.g. "UTC" or "GMT"; empty for server exports
+	 * @param string $entitiesXmlPath Last path segment and filename of the entities.xml, e.g. "my_space/entities.xml"
+	 * @return void
+	 */
+	public function addExportProperties(
+		string $spaceKey, string $source,
+		string $confluenceVersion, string $exportDate,
+		string $timezoneId, string $entitiesXmlPath
+	): void {
+		$stmt = $this->cachedPrepare(
+			'INSERT INTO export_properties
+				(space_key, source, confluence_version, export_date, timezone_id, entities_xml_path)
+			VALUES
+				(:space_key, :source, :confluence_version, :export_date, :timezone_id, :entities_xml_path)'
+		);
+		$stmt->bindValue( ':space_key', $spaceKey, SQLITE3_TEXT );
+		$stmt->bindValue( ':source', $source, SQLITE3_TEXT );
+		$stmt->bindValue( ':confluence_version', $confluenceVersion, SQLITE3_TEXT );
+		$stmt->bindValue( ':export_date', $exportDate, SQLITE3_TEXT );
+		$stmt->bindValue( ':timezone_id', $timezoneId, SQLITE3_TEXT );
+		$stmt->bindValue( ':entities_xml_path', $entitiesXmlPath, SQLITE3_TEXT );
+		$stmt->execute()->finalize();
 	}
 
 	/**

--- a/tests/phpunit/Analyzer/ExportDescriptorTest.php
+++ b/tests/phpunit/Analyzer/ExportDescriptorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Analyzer;
+
+use HalloWelt\MigrateConfluence\Analyzer\ConfluenceAnalyzer;
+use HalloWelt\MigrateConfluence\Analyzer\DataWriter\AnalyzeDirectDataWriter;
+use HalloWelt\MigrateConfluence\Tests\Database\ExportPropertiesQueryHelper;
+use HalloWelt\MigrateConfluence\Tests\Database\WorkspaceDbMock;
+use HalloWelt\MigrateConfluence\Utility\MigrationConfig;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @covers \HalloWelt\MigrateConfluence\Analyzer\ConfluenceAnalyzer::analyze
+ */
+class ExportDescriptorTest extends TestCase {
+	use ExportPropertiesQueryHelper;
+
+	private string $tempDir;
+
+	protected function setUp(): void {
+		$this->tempDir = sys_get_temp_dir() . '/confluence-export-descriptor-test-' . uniqid();
+		mkdir( $this->tempDir );
+	}
+
+	protected function tearDown(): void {
+		foreach ( glob( $this->tempDir . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $this->tempDir );
+	}
+
+	public function testExportDescriptorIsWrittenToDb(): void {
+		$minimalXml = '<?xml version="1.0" encoding="UTF-8"?>'
+			. '<hibernate-generic datetime="2020-01-01 00:00:00"></hibernate-generic>';
+		file_put_contents( $this->tempDir . '/entities.xml', $minimalXml );
+		file_put_contents(
+			$this->tempDir . '/exportDescriptor.properties',
+			"#Mon May 18 11:58:00 CEST 2026\n" .
+			"source=server\n" .
+			"createdByVersionNumber=6.15.9\n" .
+			"spaceKey=HR\n"
+		);
+
+		$workspaceDB = ( new WorkspaceDbMock() )->createEmpty();
+
+		$analyzer = new ConfluenceAnalyzer(
+			new AnalyzeDirectDataWriter( $workspaceDB ),
+			$workspaceDB,
+			new NullOutput(),
+			new MigrationConfig( [] )
+		);
+
+		$analyzer->analyze( new SplFileInfo( $this->tempDir . '/entities.xml' ) );
+
+		$rows = $this->queryExportProperties( $workspaceDB );
+		$this->assertCount( 1, $rows );
+
+		$row = $rows[0];
+		$this->assertSame( 'HR', $row['space_key'] );
+		$this->assertSame( 'server', $row['source'] );
+		$this->assertSame( '6.15.9', $row['confluence_version'] );
+		$this->assertSame( 'Mon May 18 11:58:00 CEST 2026', $row['export_date'] );
+		$this->assertSame( '', $row['timezone_id'] );
+		$this->assertStringEndsWith( '/entities.xml', $row['entities_xml_path'] );
+		$this->assertStringNotContainsString( sys_get_temp_dir(), $row['entities_xml_path'] );
+	}
+
+	public function testMissingDescriptorFileIsSkippedGracefully(): void {
+		$minimalXml = '<?xml version="1.0" encoding="UTF-8"?>'
+			. '<hibernate-generic datetime="2020-01-01 00:00:00"></hibernate-generic>';
+		file_put_contents( $this->tempDir . '/entities.xml', $minimalXml );
+
+		$workspaceDB = ( new WorkspaceDbMock() )->createEmpty();
+
+		$analyzer = new ConfluenceAnalyzer(
+			new AnalyzeDirectDataWriter( $workspaceDB ),
+			$workspaceDB,
+			new NullOutput(),
+			new MigrationConfig( [] )
+		);
+
+		$analyzer->analyze( new SplFileInfo( $this->tempDir . '/entities.xml' ) );
+
+		$this->assertCount( 0, $this->queryExportProperties( $workspaceDB ) );
+	}
+
+	public function testNonEntitiesXmlFileIsIgnored(): void {
+		$workspaceDB = ( new WorkspaceDbMock() )->createEmpty();
+
+		$analyzer = new ConfluenceAnalyzer(
+			new AnalyzeDirectDataWriter( $workspaceDB ),
+			$workspaceDB,
+			new NullOutput(),
+			new MigrationConfig( [] )
+		);
+
+		$result = $analyzer->analyze( new SplFileInfo( $this->tempDir . '/something-else.xml' ) );
+
+		$this->assertTrue( $result );
+		$this->assertCount( 0, $this->queryExportProperties( $workspaceDB ) );
+	}
+}

--- a/tests/phpunit/Database/ExportPropertiesQueryHelper.php
+++ b/tests/phpunit/Database/ExportPropertiesQueryHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Database;
+
+use HalloWelt\MigrateConfluence\Database\WorkspaceDB;
+use ReflectionClass;
+
+trait ExportPropertiesQueryHelper {
+
+	private function queryExportProperties( WorkspaceDB $db ): array {
+		$sqliteDb = ( new ReflectionClass( WorkspaceDB::class ) )
+			->getProperty( 'db' )
+			->getValue( $db );
+		$result = $sqliteDb->query( 'SELECT * FROM export_properties' );
+		$rows = [];
+		$row = $result->fetchArray( SQLITE3_ASSOC );
+		while ( $row !== false ) {
+			$rows[] = $row;
+			$row = $result->fetchArray( SQLITE3_ASSOC );
+		}
+		return $rows;
+	}
+}

--- a/tests/phpunit/Database/ExportPropertiesTest.php
+++ b/tests/phpunit/Database/ExportPropertiesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \HalloWelt\MigrateConfluence\Database\WorkspaceDB::addExportProperties
+ */
+class ExportPropertiesTest extends TestCase {
+	use ExportPropertiesQueryHelper;
+
+	public function testStoresAllFields(): void {
+		$db = ( new WorkspaceDbMock() )->createEmpty();
+
+		$db->addExportProperties(
+			'HR',
+			'server',
+			'7.19.18',
+			'Fri Jul 03 09:54:18 CEST 2026',
+			'',
+			'_data_h_input_HH/entities.xml'
+		);
+
+		$rows = $this->queryExportProperties( $db );
+		$this->assertCount( 1, $rows );
+
+		$row = $rows[0];
+		$this->assertSame( 'HR', $row['space_key'] );
+		$this->assertSame( 'server', $row['source'] );
+		$this->assertSame( '7.19.18', $row['confluence_version'] );
+		$this->assertSame( 'Fri Jul 03 09:54:18 CEST 2026', $row['export_date'] );
+		$this->assertSame( '', $row['timezone_id'] );
+		$this->assertSame( '_data_h_input_HH/entities.xml', $row['entities_xml_path'] );
+	}
+
+	public function testCloudExportWithTimezone(): void {
+		$db = ( new WorkspaceDbMock() )->createEmpty();
+
+		$db->addExportProperties(
+			'ZVA',
+			'cloud',
+			'1000.0.0-8e2084093f58',
+			'Thu Mar 19 15:41:51 UTC 2026',
+			'GMT',
+			'_data_g_input/entities.xml'
+		);
+
+		$rows = $this->queryExportProperties( $db );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'cloud', $rows[0]['source'] );
+		$this->assertSame( 'GMT', $rows[0]['timezone_id'] );
+	}
+}


### PR DESCRIPTION
The file `exportDescriptor.properties` contains metadata about the current export, e.g. the time zone of the instance and the version. We store this info now into the `export_properties` table for later use (e.g., fine-tune macro migrations based on version).

ERM49159