### PR TITLE
fix blog post revisions not being found

### DIFF
--- a/src/Extractor/Processor/ExtractBlogPostsBodyContents.php
+++ b/src/Extractor/Processor/ExtractBlogPostsBodyContents.php
@@ -11,7 +11,7 @@ class ExtractBlogPostsBodyContents extends ExtractSpaceDescriptionBodyContents {
 	 */
 	public function execute(): void {
 		$currentContentIds = [];
-		foreach ( $this->workspaceDB->getCurrentBlogPosts() as $blogPost ) {
+		foreach ( $this->workspaceDB->getBlogPosts() as $blogPost ) {
 			if ( isset( $blogPost['page_id'] ) ) {
 				$currentContentIds[] = (int)$blogPost['page_id'];
 			}

--- a/tests/phpunit/Database/BlogPostRevisionsTest.php
+++ b/tests/phpunit/Database/BlogPostRevisionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace HalloWelt\MigrateConfluence\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \HalloWelt\MigrateConfluence\Database\WorkspaceDB::getBlogPostRevisionsForBlogPostId
+ */
+class BlogPostRevisionsTest extends TestCase {
+
+	public function testCurrentVersionIsReturned(): void {
+		$db = ( new WorkspaceDbMock() )->createEmpty();
+
+		$db->addBlogPost(
+			100, 1, 'My Post', 'Blog:MKT/My_Post',
+			'current', '20240301000000', '', '1', -1, [], [], [], []
+		);
+
+		$revisions = $db->getBlogPostRevisionsForBlogPostId( 100 );
+		$this->assertCount( 1, $revisions );
+		$this->assertSame( '20240301000000', $revisions[0]['revision_timestamp'] );
+	}
+
+	/**
+	 * In Confluence exports, historical blog post versions have content_status = 'draft'
+	 * and original_version_id pointing at the canonical (current) page_id.
+	 * The composer needs these to build revision history.
+	 */
+	public function testHistoricalDraftVersionIsReturned(): void {
+		$db = ( new WorkspaceDbMock() )->createEmpty();
+
+		// Historical version (old revision) stored as draft
+		$db->addBlogPost(
+			99, 1, 'My Post', 'Blog:MKT/My_Post',
+			'draft', '20240201000000', '', '1', 100, [], [], [], []
+		);
+		// Current version
+		$db->addBlogPost(
+			100, 1, 'My Post', 'Blog:MKT/My_Post',
+			'current', '20240301000000', '', '2', -1, [], [], [], []
+		);
+
+		$revisions = $db->getBlogPostRevisionsForBlogPostId( 100 );
+		$this->assertCount( 2, $revisions );
+		$timestamps = array_column( $revisions, 'revision_timestamp' );
+		$this->assertContains( '20240201000000', $timestamps );
+		$this->assertContains( '20240301000000', $timestamps );
+	}
+
+	/**
+	 * A standalone unpublished draft (original_version_id = -1, content_status = 'draft')
+	 * must not appear in the revisions of any other post.
+	 */
+	public function testStandaloneDraftIsNotReturnedForOtherPost(): void {
+		$db = ( new WorkspaceDbMock() )->createEmpty();
+
+		// Standalone unpublished draft — unrelated to post 100
+		$db->addBlogPost(
+			77, 1, 'Unpublished', 'Blog:MKT/Unpublished',
+			'draft', '20240101000000', '', '1', -1, [], [], [], []
+		);
+		// Current post
+		$db->addBlogPost(
+			100, 1, 'My Post', 'Blog:MKT/My_Post',
+			'current', '20240301000000', '', '1', -1, [], [], [], []
+		);
+
+		$revisions = $db->getBlogPostRevisionsForBlogPostId( 100 );
+		$this->assertCount( 1, $revisions );
+		$this->assertSame( '20240301000000', $revisions[0]['revision_timestamp'] );
+	}
+}

--- a/tests/phpunit/Extractor/Processor/ExtractBlogPostsBodyContentsTest.php
+++ b/tests/phpunit/Extractor/Processor/ExtractBlogPostsBodyContentsTest.php
@@ -20,7 +20,7 @@ class ExtractBlogPostsBodyContentsTest extends TestCase {
 		$dbLog = $this->createMock( DBLog::class );
 		$writer = $this->createMock( ExtractorDirectDataWriter::class );
 
-		$workspaceDB->method( 'getCurrentBlogPosts' )->willReturn( [ [ 'page_id' => 13 ] ] );
+		$workspaceDB->method( 'getBlogPosts' )->willReturn( [ [ 'page_id' => 13 ] ] );
 		$workspaceDB->method( 'getBodyContentIdsForContentId' )->with( 13 )->willReturn( [ 103 ] );
 		$workspaceDB->method( 'getBodyContentBodyByBodyContentId' )->with( 103 )->willReturn( 'Blog body' );
 
@@ -30,6 +30,43 @@ class ExtractBlogPostsBodyContentsTest extends TestCase {
 			->willReturn( '/content/raw/103.mraw' );
 
 		$dbLog->expects( $this->once() )->method( 'addLogEntry' );
+
+		$processor = new ExtractBlogPostsBodyContents( $workspaceDB, $workspace, $dbLog, $writer );
+		$processor->execute();
+	}
+
+	/**
+	 * Historical blog post versions have content_status = 'draft' in Confluence exports.
+	 * They must be extracted so the composer can build revision history.
+	 *
+	 * @covers \HalloWelt\MigrateConfluence\Extractor\Processor\ExtractBlogPostsBodyContents::execute
+	 */
+	public function testExtractsHistoricalBlogPostBodyContent(): void {
+		$workspaceDB = $this->createMock( WorkspaceDB::class );
+		$workspace = $this->createMock( Workspace::class );
+		$dbLog = $this->createMock( DBLog::class );
+		$writer = $this->createMock( ExtractorDirectDataWriter::class );
+
+		// Both the current version (page_id=20) and a historical draft (page_id=19)
+		// are returned by getBlogPosts().
+		$workspaceDB->method( 'getBlogPosts' )->willReturn( [
+			[ 'page_id' => 20 ],
+			[ 'page_id' => 19 ],
+		] );
+		$workspaceDB->method( 'getBodyContentIdsForContentId' )
+			->willReturnMap( [
+				[ 20, [ 200 ] ],
+				[ 19, [ 190 ] ],
+			] );
+		$workspaceDB->method( 'getBodyContentBodyByBodyContentId' )
+			->willReturnMap( [
+				[ 200, 'Current body' ],
+				[ 190, 'Historical body' ],
+			] );
+
+		$workspace->expects( $this->exactly( 2 ) )
+			->method( 'saveRawContent' )
+			->willReturn( '/content/raw/x.mraw' );
 
 		$processor = new ExtractBlogPostsBodyContents( $workspaceDB, $workspace, $dbLog, $writer );
 		$processor->execute();


### PR DESCRIPTION
The problem: Old blog post revisions are automatically marked as
"draft". We look through drafts now, too, specifically for historic
versions of blog posts. Draft posts themselves are still ignored.

ERM49476
