### PR TITLE
fix stray "|body" parameter

### DIFF
--- a/src/Converter/Processor/TableFilterMacro.php
+++ b/src/Converter/Processor/TableFilterMacro.php
@@ -61,7 +61,7 @@ class TableFilterMacro extends ConvertMacroToTemplateWithBodyBase {
 		}
 
 		if ( !empty( $richTextBodyEls ) ) {
-			$bodyString = "|body = ";
+			$bodyString = "";
 			if ( $this->addLinebreakInsideTemplate() ) {
 				$bodyString .= "###BREAK###\n";
 			}

--- a/tests/phpunit/data/table-filter-macro-output.wikitext
+++ b/tests/phpunit/data/table-filter-macro-output.wikitext
@@ -14,7 +14,7 @@
 |worklog = 365|5|8|y w d h m|y w d h m
 |isOR = AND
 |order = 0,1
-}}|body = 
+}}
 
 {| class="wikitable fixed-table wrapped datagrid"
 |-

--- a/tests/phpunit/data/table-filter-macro-output.xml
+++ b/tests/phpunit/data/table-filter-macro-output.xml
@@ -16,7 +16,7 @@
 |worklog = 365|5|8|y w d h m|y w d h m###BREAK###
 |isOR = AND###BREAK###
 |order = 0,1###BREAK###
-}}|body = ###BREAK###
+}}###BREAK###
 <table class="fixed-table wrapped datagrid">
 				<colgroup>
 					<col style="width: 38.0px;"/>


### PR DESCRIPTION
The TableFilterMacro added an unnecessary `|body =`, since the body is actually sandwiched between a `TableFilterStart` and a `TableFilterEnd` template. This PR strips that away.

ERM48553
