### PR TITLE
fix bash arrays with empty strings

### DIFF
--- a/src/Composer/_shell/spaceimport.sh
+++ b/src/Composer/_shell/spaceimport.sh
@@ -124,7 +124,9 @@ collect_xml_files() {
     files+=("${split_files[@]}")
   fi
 
-  printf "%q\n" "${files[@]}"
+  if (( ${#files[@]} > 0 )); then
+    printf "%q\n" "${files[@]}"
+  fi
 }
 
 run_import_dump_file() {

--- a/src/Composer/_shell/wikiimport.sh
+++ b/src/Composer/_shell/wikiimport.sh
@@ -119,7 +119,9 @@ collect_xml_files() {
     files+=("${split_files[@]}")
   fi
 
-  printf '%s\n' "${files[@]}"
+  if (( ${#files[@]} > 0 )); then
+    printf '%s\n' "${files[@]}"
+  fi
 }
 
 run_import_dump_file() {


### PR DESCRIPTION
If no files were found, the bash array would contain
an empty string as sole entry. The script would then
try to import this "file".
